### PR TITLE
Initial `Mul` implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Marked for Deprecation
 
-## [v0.1.0]
+## [v0.1.0] (work in progress)
 
-> Initial releaso
+> Initial release
 
 ### Removed
 
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Positive integers
 - Subtraction evaluation 
 - Addition evaluaton
+- Multiplication evaluaton
 - `CHANGELOG.md`
 
 ### Marked for Deprecation

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2,6 +2,7 @@
 
 /// Addition expressions
 mod add;
+mod mul;
 /// Subtraction expressions
 mod sub;
 

--- a/src/expr/add.rs
+++ b/src/expr/add.rs
@@ -10,7 +10,7 @@ where
     L: Expr,
     R: Expr,
 {
-    type Ret = <Add<L::Ret, R::Ret, Base> as Expr>::Ret;
+    type Ret = ExpRet<Add<L::Ret, R::Ret, Base>>;
 }
 
 // ----
@@ -32,8 +32,11 @@ impl Expr for Add<_1, _1, Base> {
 // ---
 // Non-carry bit-additions to bit-string literal
 // ---
-impl Expr for Add<BitString<_1, _0>, _1, Base> {
-    type Ret = BitString<_1, _1>;
+impl<B> Expr for Add<BitString<B, _0>, _1, Base>
+where
+    B: BitStrLit,
+{
+    type Ret = BitString<B, _1>;
 }
 impl Expr for Add<_1, BitString<_1, _0>, Base> {
     type Ret = BitString<_1, _1>;
@@ -111,6 +114,7 @@ mod test {
         const _1_ADD_3: () = _b4::<Add<_1, BitString<_1, _1>>>();
         const _2_ADD_2: () = _b4::<Add<BitString<_1, _0>, BitString<_1, _0>>>();
         const _3_ADD_3: () = _b6::<Add<BitString<_1, _1>, BitString<_1, _1>>>();
+        const _6_ADD_1: () = _b7::<Add<BitString<BitString<_1, _1>, _0>, _1>>();
         const _7_ADD_1: () = _b8::<Add<BitString<BitString<_1, _1>, _1>, _1>>();
     }
 }

--- a/src/expr/mul.rs
+++ b/src/expr/mul.rs
@@ -1,0 +1,81 @@
+use crate::{
+    op_types::{Add, Mul},
+    val_types::{BitLit, BitStrLit, BitString, Number, _0, _1},
+    Base, ExpRet, Expr,
+};
+
+impl<L, R> Expr for Mul<L, R>
+where
+    L: Expr,
+    R: Expr,
+    Mul<L::Ret, R::Ret, Base>: Expr,
+{
+    type Ret = ExpRet<Mul<L::Ret, R::Ret, Base>>;
+}
+// -------------
+// Hard codod base cases.
+// Past attempts to coallesce these impls resulted in overlapping-impl headaches
+// -------------
+
+impl Expr for Mul<_0, _1, Base> {
+    type Ret = _0;
+}
+impl Expr for Mul<_1, _0, Base> {
+    type Ret = _0;
+}
+impl Expr for Mul<_0, _0, Base> {
+    type Ret = _0;
+}
+impl Expr for Mul<_1, _1, Base> {
+    type Ret = _1;
+}
+impl<Bs, B> Expr for Mul<_1, BitString<Bs, B>, Base>
+where
+    Bs: Expr,
+    B: BitLit,
+    BitString<Bs, B>: Number,
+{
+    type Ret = BitString<Bs, B>;
+}
+
+// (LB, _1) * Val == ((LB * Val), _0) + Val
+impl<LB, Val> Expr for Mul<BitString<LB, _1>, Val, Base>
+where
+    LB: BitStrLit,
+    Mul<LB, Val>: Expr,
+    Add<BitString<ExpRet<Mul<LB, Val>>, _0>, Val>: Expr,
+{
+    type Ret = ExpRet<Add<BitString<ExpRet<Mul<LB, Val>>, _0>, Val>>;
+}
+// (LB, _0) * Val == ((LB * Val), _0)
+impl<LB, Val> Expr for Mul<BitString<LB, _0>, Val, Base>
+where
+    LB: BitStrLit,
+    Mul<LB, Val>: Expr,
+    ExpRet<Mul<LB, Val>>: BitStrLit,
+{
+    type Ret = BitString<ExpRet<Mul<LB, Val>>, _0>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_res::*;
+    #[test]
+    fn eval_add() {
+        const _0_MUL_0: () = _b0::<Mul<_0, _0>>();
+        const _0_MUL_1: () = _b0::<Mul<_0, _1>>();
+        const _1_MUL_0: () = _b0::<Mul<_1, _0>>();
+        const _2_MUL_1: () = _b2::<Mul<BitString<_1, _0>, _1>>();
+        const _1_MUL_2: () = _b2::<Mul<_1, BitString<_1, _0>>>();
+        const _3_MUL_1: () = _b3::<Mul<BitString<_1, _1>, _1>>();
+        const _1_MUL_3: () = _b3::<Mul<_1, BitString<_1, _1>>>();
+        const _2_MUL_2: () = _b4::<Mul<BitString<_1, _0>, BitString<_1, _0>>>();
+        const _4_MUL_1: () = _b4::<Mul<BitString<BitString<_1, _0>, _0>, _1>>();
+        const _5_MUL_1: () = _b5::<Mul<BitString<BitString<_1, _0>, _1>, _1>>();
+        const _6_MUL_1: () = _b6::<Mul<BitString<BitString<_1, _1>, _0>, _1>>();
+        const _7_MUL_1: () = _b7::<Mul<BitString<BitString<_1, _1>, _1>, _1>>();
+        const _8_MUL_1: () = _b8::<Mul<BitString<BitString<BitString<_1, _0>, _0>, _0>, _1>>();
+        const _3_MUL_3: () = _b9::<Mul<BitString<_1, _1>, BitString<_1, _1>>>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 mod op_types;
 mod val_types;
 use val_types::Number;
@@ -28,7 +29,9 @@ mod test_res {
     pub(crate) const fn _b4<E: Expr<Ret = BitString<BitString<_1, _0>, _0>>>() {}
     pub(crate) const fn _b5<E: Expr<Ret = BitString<BitString<_1, _0>, _1>>>() {}
     pub(crate) const fn _b6<E: Expr<Ret = BitString<BitString<_1, _1>, _0>>>() {}
+    pub(crate) const fn _b7<E: Expr<Ret = BitString<BitString<_1, _1>, _1>>>() {}
     pub(crate) const fn _b8<E: Expr<Ret = BitString<BitString<BitString<_1, _0>, _0>, _0>>>() {}
+    pub(crate) const fn _b9<E: Expr<Ret = BitString<BitString<BitString<_1, _0>, _0>, _1>>>() {}
     #[test]
     fn eval_add() {
         const _0_0: () = _b0::<BitString<_0, _0>>();

--- a/src/op_types.rs
+++ b/src/op_types.rs
@@ -12,6 +12,11 @@ pub struct Sub<Lhs, Rhs, M = Recurse> {
     _r: PhantomData<Rhs>,
     _m: PhantomData<M>,
 }
+pub struct Mul<Lhs, Rhs, M = Recurse> {
+    _l: PhantomData<Lhs>,
+    _r: PhantomData<Rhs>,
+    _m: PhantomData<M>,
+}
 // pub struct BitAnd<L, R, M: Mode = Ast> {
 //     _l: PhantomData<L>,
 //     _r: PhantomData<R>,


### PR DESCRIPTION
Also fixes the add base case: now a single increment for all 0-terminatod bitstrings are accounted for (instead of only `10`)