### PR TITLE
Inner uses core ops

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -12,28 +12,25 @@ mod test {
     use crate::{
         op_types::{Add, ShL, Sub, MSB},
         test_res::*,
-        val_types::{BitString, _0, _1},
+        U0, U1, U2, U3, U4, U6,
     };
 
     #[test]
     #[allow(non_upper_case_globals)]
     fn add_sub() {
         // const _2_ADD_1_SUB_3: () = _b3::<Add<BitString<_1, _0>, _1>>();
-        const _2_ADD_1__SUB_3: () = _b0::<Sub<Add<BitString<_1, _0>, _1>, BitString<_1, _1>>>();
-        const _6_SUB__1_ADD_3: () =
-            _b2::<Sub<BitString<BitString<_1, _1>, _0>, Add<_1, BitString<_1, _1>>>>();
+        const _2_ADD_1__SUB_3: () = _b0::<Sub<Add<U2, U1>, U3>>();
+        const _6_SUB__1_ADD_3: () = _b2::<Sub<U6, Add<U1, U3>>>();
     }
 
     #[test]
     #[allow(non_upper_case_globals)]
     fn shift_msb() {
         // const _2_ADD_1_SUB_3: () = _b3::<Add<BitString<_1, _0>, _1>>();
-        const _MSB__2_SHL_1: () = _b2::<MSB<ShL<BitString<_1, _0>, _1>>>();
-        const _MSB__2_SHL_0: () = _b1::<MSB<ShL<BitString<_1, _0>, _0>>>();
+        const _MSB__2_SHL_1: () = _b2::<MSB<ShL<U2, U1>>>();
+        const _MSB__2_SHL_0: () = _b1::<MSB<ShL<U2, U0>>>();
 
-        const _MSB_4__SUB__MSB_3: () =
-            _b1::<Sub<MSB<BitString<BitString<_1, _0>, _0>>, MSB<BitString<_1, _1>>>>();
-        const _MSB_4__ADD__MSB_3: () =
-            _b3::<Add<MSB<BitString<BitString<_1, _0>, _0>>, MSB<BitString<_1, _1>>>>();
+        const _MSB_4__SUB__MSB_3: () = _b1::<Sub<MSB<U4>, MSB<U3>>>();
+        const _MSB_4__ADD__MSB_3: () = _b3::<Add<MSB<U4>, MSB<U3>>>();
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -10,7 +10,7 @@ mod sub;
 #[cfg(test)]
 mod test {
     use crate::{
-        op_types::{Add, ShL, Sub, MSB},
+        op_types::{AddExp, ShLExp, SubExp, MSB},
         test_res::*,
         U0, U1, U2, U3, U4, U6,
     };
@@ -19,18 +19,18 @@ mod test {
     #[allow(non_upper_case_globals)]
     fn add_sub() {
         // const _2_ADD_1_SUB_3: () = _b3::<Add<BitString<_1, _0>, _1>>();
-        const _2_ADD_1__SUB_3: () = _b0::<Sub<Add<U2, U1>, U3>>();
-        const _6_SUB__1_ADD_3: () = _b2::<Sub<U6, Add<U1, U3>>>();
+        const _2_ADD_1__SUB_3: () = _b0::<SubExp<AddExp<U2, U1>, U3>>();
+        const _6_SUB__1_ADD_3: () = _b2::<SubExp<U6, AddExp<U1, U3>>>();
     }
 
     #[test]
     #[allow(non_upper_case_globals)]
     fn shift_msb() {
         // const _2_ADD_1_SUB_3: () = _b3::<Add<BitString<_1, _0>, _1>>();
-        const _MSB__2_SHL_1: () = _b2::<MSB<ShL<U2, U1>>>();
-        const _MSB__2_SHL_0: () = _b1::<MSB<ShL<U2, U0>>>();
+        const _MSB__2_SHL_1: () = _b2::<MSB<ShLExp<U2, U1>>>();
+        const _MSB__2_SHL_0: () = _b1::<MSB<ShLExp<U2, U0>>>();
 
-        const _MSB_4__SUB__MSB_3: () = _b1::<Sub<MSB<U4>, MSB<U3>>>();
-        const _MSB_4__ADD__MSB_3: () = _b3::<Add<MSB<U4>, MSB<U3>>>();
+        const _MSB_4__SUB__MSB_3: () = _b1::<SubExp<MSB<U4>, MSB<U3>>>();
+        const _MSB_4__ADD__MSB_3: () = _b3::<AddExp<MSB<U4>, MSB<U3>>>();
     }
 }

--- a/src/expr/add.rs
+++ b/src/expr/add.rs
@@ -1,7 +1,7 @@
 use crate::{
     op_types::Add,
     val_types::{BitStrLit, BitString, _0, _1},
-    Base, NumExpr, NumRet,
+    Base, NumExpr, NumRet, U0, U1,
 };
 
 impl<L, R> NumExpr for Add<L, R>
@@ -16,54 +16,54 @@ where
 // ----
 //  Most basic of addition evaluations
 // ----
-impl NumExpr for Add<_0, _0, Base> {
-    type Ret = _0;
+impl NumExpr for Add<U0, U0, Base> {
+    type Ret = U0;
 }
-impl NumExpr for Add<_0, _1, Base> {
-    type Ret = _1;
+impl NumExpr for Add<U0, U1, Base> {
+    type Ret = U1;
 }
-impl NumExpr for Add<_1, _0, Base> {
-    type Ret = _1;
+impl NumExpr for Add<U1, U0, Base> {
+    type Ret = U1;
 }
-impl NumExpr for Add<_1, _1, Base> {
-    type Ret = BitString<_1, _0>;
+impl NumExpr for Add<U1, U1, Base> {
+    type Ret = BitString<U1, _0>;
 }
 
 // ---
 // Non-carry bit-additions to bit-string literal
 // ---
-impl<B> NumExpr for Add<BitString<B, _0>, _1, Base>
+impl<B> NumExpr for Add<BitString<B, _0>, U1, Base>
 where
     B: BitStrLit,
 {
     type Ret = BitString<B, _1>;
 }
-impl<B> NumExpr for Add<_1, BitString<B, _0>, Base>
+impl<B> NumExpr for Add<U1, BitString<B, _0>, Base>
 where
     B: BitStrLit,
 {
-    type Ret = BitString<_1, _1>;
+    type Ret = BitString<U1, _1>;
 }
 
 // ---
 // Carrying increment to a bit-string-literal
 // ---
-impl<B> NumExpr for Add<BitString<B, _1>, _1, Base>
+impl<B> NumExpr for Add<BitString<B, _1>, U1, Base>
 where
     // Recurse the carry
-    Add<B, _1>: NumExpr,
+    Add<B, U1>: NumExpr,
     // Ensure the carry recursion is a valid progression
-    NumRet<Add<B, _1>>: BitStrLit,
+    NumRet<Add<B, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<B, _1>>, _0>;
+    type Ret = BitString<NumRet<Add<B, U1>>, _0>;
 }
 
-impl<B> NumExpr for Add<_1, BitString<B, _1>, Base>
+impl<B> NumExpr for Add<U1, BitString<B, _1>, Base>
 where
-    Add<B, _1>: NumExpr,
-    NumRet<Add<B, _1>>: BitStrLit,
+    Add<B, U1>: NumExpr,
+    NumRet<Add<B, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<B, _1>>, _0>;
+    type Ret = BitString<NumRet<Add<B, U1>>, _0>;
 }
 
 // ---
@@ -97,35 +97,33 @@ impl<LB, RB> NumExpr for Add<BitString<LB, _1>, BitString<RB, _1>, Base>
 where
     Add<LB, RB>: NumExpr,
     NumRet<Add<LB, RB>>: NumExpr,
-    Add<NumRet<NumRet<Add<LB, RB>>>, _1>: NumExpr,
-    NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, _1>>: BitStrLit,
+    Add<NumRet<NumRet<Add<LB, RB>>>, U1>: NumExpr,
+    NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, _1>>, _0>;
+    type Ret = BitString<NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, U1>>, _0>;
 }
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_res::*;
+    use crate::{test_res::*, U0, U1, U2, U3, U6, U7};
     #[test]
     fn eval_add() {
-        const _0_ADD_0: () = _b0::<Add<_0, _0>>();
-        const _1_ADD_0: () = _b1::<Add<_1, _0>>();
-        const _1_ADD_1: () = _b2::<Add<_1, _1>>();
-        const _2_ADD_1: () = _b3::<Add<BitString<_1, _0>, _1>>();
-        const _1_ADD_2: () = _b3::<Add<_1, BitString<_1, _0>>>();
-        const _3_ADD_1: () = _b4::<Add<BitString<_1, _1>, _1>>();
-        const _1_ADD_3: () = _b4::<Add<_1, BitString<_1, _1>>>();
-        const _2_ADD_2: () = _b4::<Add<BitString<_1, _0>, BitString<_1, _0>>>();
-        const _3_ADD_3: () = _b6::<Add<BitString<_1, _1>, BitString<_1, _1>>>();
-        const _6_ADD_1: () = _b7::<Add<BitString<BitString<_1, _1>, _0>, _1>>();
-        const _7_ADD_1: () = _b8::<Add<BitString<BitString<_1, _1>, _1>, _1>>();
+        const _0_ADD_0: () = _b0::<Add<U0, U0>>();
+        const _1_ADD_0: () = _b1::<Add<U1, U0>>();
+        const _1_ADD_1: () = _b2::<Add<U1, U1>>();
+        const _2_ADD_1: () = _b3::<Add<U2, U1>>();
+        const _1_ADD_2: () = _b3::<Add<U1, U2>>();
+        const _3_ADD_1: () = _b4::<Add<U3, U1>>();
+        const _1_ADD_3: () = _b4::<Add<U1, U3>>();
+        const _2_ADD_2: () = _b4::<Add<U2, U2>>();
+        const _3_ADD_3: () = _b6::<Add<U3, U3>>();
+        const _6_ADD_1: () = _b7::<Add<U6, U1>>();
+        const _7_ADD_1: () = _b8::<Add<U7, U1>>();
 
-        const _1_ADD_1__ADD_1: () = _b3::<Add<_1, Add<_1, _1>>>();
-        const _1_ADD__1_ADD_1: () = _b3::<Add<Add<_1, _1>, _1>>();
+        const _1_ADD_1__ADD_1: () = _b3::<Add<U1, Add<U1, U1>>>();
+        const _1_ADD__1_ADD_1: () = _b3::<Add<Add<U1, U1>, U1>>();
 
-        const _3_ADD_3__ADD_3: () =
-            _b9::<Add<BitString<_1, _1>, Add<BitString<_1, _1>, BitString<_1, _1>>>>();
-        const _3_ADD__3_ADD_3: () =
-            _b9::<Add<Add<BitString<_1, _1>, BitString<_1, _1>>, BitString<_1, _1>>>();
+        const _3_ADD_3__ADD_3: () = _b9::<Add<U3, Add<U3, U3>>>();
+        const _3_ADD__3_ADD_3: () = _b9::<Add<Add<U3, U3>, U3>>();
     }
 }

--- a/src/expr/add.rs
+++ b/src/expr/add.rs
@@ -1,106 +1,148 @@
 use crate::{
     op_types::AddExp,
-    val_types::{BitStrLit, BitString, _0, _1},
-    Base, NumExpr, NumRet, U0, U1,
+    val_types::{BitStrLit, BitString, NumberVal, _0, _1},
+    NumExpr, U0, U1,
 };
+use core::ops::Add as StAdd;
+
+pub type AddOut<L, R> = <L as StAdd<R>>::Output;
 
 impl<L, R> NumExpr for AddExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    AddExp<L::Ret, R::Ret, Base>: NumExpr,
+    L::Ret: StAdd<R::Ret>,
+    AddOut<L::Ret, R::Ret>: NumberVal,
 {
-    type Ret = NumRet<AddExp<L::Ret, R::Ret, Base>>;
+    type Ret = AddOut<L::Ret, R::Ret>;
 }
 
 // ----
 //  Most basic of addition evaluations
 // ----
-impl NumExpr for AddExp<U0, U0, Base> {
-    type Ret = U0;
+impl StAdd<U0> for U0 {
+    type Output = U0;
+
+    fn add(self, _rhs: U0) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl NumExpr for AddExp<U0, U1, Base> {
-    type Ret = U1;
+impl StAdd<U1> for U0 {
+    type Output = U1;
+    fn add(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl NumExpr for AddExp<U1, U0, Base> {
-    type Ret = U1;
+impl StAdd<U0> for U1 {
+    type Output = U1;
+    fn add(self, _rhs: U0) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl NumExpr for AddExp<U1, U1, Base> {
-    type Ret = BitString<U1, _0>;
+impl StAdd<U1> for U1 {
+    type Output = BitString<U1, _0>;
+    fn add(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
 // ---
 // Non-carry bit-additions to bit-string literal
 // ---
-impl<B> NumExpr for AddExp<BitString<B, _0>, U1, Base>
+impl<B> StAdd<U1> for BitString<B, _0>
 where
     B: BitStrLit,
 {
-    type Ret = BitString<B, _1>;
+    type Output = BitString<B, _1>;
+    fn add(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl<B> NumExpr for AddExp<U1, BitString<B, _0>, Base>
+impl<B> StAdd<BitString<B, _0>> for U1
 where
     B: BitStrLit,
 {
-    type Ret = BitString<B, _1>;
+    type Output = BitString<B, _1>;
+    fn add(self, _rhs: BitString<B, _0>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
 // ---
 // Carrying increment to a bit-string-literal
 // ---
-impl<B> NumExpr for AddExp<BitString<B, _1>, U1, Base>
+impl<B> StAdd<U1> for BitString<B, _1>
 where
     // Recurse the carry
-    AddExp<B, U1>: NumExpr,
+    B: StAdd<U1>,
     // Ensure the carry recursion is a valid progression
-    NumRet<AddExp<B, U1>>: BitStrLit,
+    AddOut<B, U1>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<B, U1>>, _0>;
+    type Output = BitString<AddOut<B, U1>, _0>;
+    fn add(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
-impl<B> NumExpr for AddExp<U1, BitString<B, _1>, Base>
+impl<B> StAdd<BitString<B, _1>> for U1
 where
-    AddExp<B, U1>: NumExpr,
-    NumRet<AddExp<B, U1>>: BitStrLit,
+    B: StAdd<U1>,
+    AddOut<B, U1>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<B, U1>>, _0>;
+    type Output = BitString<AddOut<B, U1>, _0>;
+    fn add(self, _rhs: BitString<B, _1>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
 // ---
 // Addition of two bit-string literals
 // ---
 /// (LB, 0) + (RB, 0) == ((LB + RB), 0)
-impl<LB, RB> NumExpr for AddExp<BitString<LB, _0>, BitString<RB, _0>, Base>
+impl<LB, RB> StAdd<BitString<RB, _0>> for BitString<LB, _0>
 where
-    AddExp<LB, RB>: NumExpr,
-    NumRet<AddExp<LB, RB>>: BitStrLit,
+    LB: StAdd<RB>,
+    AddOut<LB, RB>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<LB, RB>>, _0>;
+    type Output = BitString<AddOut<LB, RB>, _0>;
+    fn add(self, _rhs: BitString<RB, _0>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 /// (LB, 0) + (RB, 1) == ((LB + RB), 1)
-impl<LB, RB> NumExpr for AddExp<BitString<LB, _0>, BitString<RB, _1>, Base>
+impl<LB, RB> StAdd<BitString<RB, _1>> for BitString<LB, _0>
 where
-    AddExp<LB, RB>: NumExpr,
-    NumRet<AddExp<LB, RB>>: BitStrLit,
+    LB: StAdd<RB>,
+    AddOut<LB, RB>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<LB, RB>>, _1>;
+    type Output = BitString<AddOut<LB, RB>, _1>;
+    fn add(self, _rhs: BitString<RB, _1>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl<LB, RB> NumExpr for AddExp<BitString<LB, _1>, BitString<RB, _0>, Base>
+impl<LB, RB> StAdd<BitString<RB, _0>> for BitString<LB, _1>
 where
-    AddExp<LB, RB>: NumExpr,
-    NumRet<AddExp<LB, RB>>: BitStrLit,
+    LB: StAdd<RB>,
+    AddOut<LB, RB>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<LB, RB>>, _1>;
+    type Output = BitString<AddOut<LB, RB>, _1>;
+    fn add(self, _rhs: BitString<RB, _0>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 /// (LB, 1) + (RB, 1) == ((LB + RB) + 1, 1)
-impl<LB, RB> NumExpr for AddExp<BitString<LB, _1>, BitString<RB, _1>, Base>
+impl<LB, RB> StAdd<BitString<RB, _1>> for BitString<LB, _1>
 where
-    AddExp<LB, RB>: NumExpr,
-    NumRet<AddExp<LB, RB>>: NumExpr,
-    AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>: NumExpr,
-    NumRet<AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>>: BitStrLit,
+    LB: StAdd<RB>,
+    AddOut<LB, RB>: BitStrLit + StAdd<U1>,
+    AddOut<AddOut<LB, RB>, U1>: BitStrLit,
+    // AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>: NumExpr,
+    // NumRet<AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>>, _0>;
+    type Output = BitString<AddOut<AddOut<LB, RB>, U1>, _0>;
+    fn add(self, _rhs: BitString<RB, _1>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 #[cfg(test)]
 mod test {
@@ -114,6 +156,7 @@ mod test {
         const _2_ADD_1: () = _b3::<AddExp<U2, U1>>();
         const _1_ADD_2: () = _b3::<AddExp<U1, U2>>();
         const _3_ADD_1: () = _b4::<AddExp<U3, U1>>();
+        const _4_ADD_1: () = _b5::<AddExp<U4, U1>>();
         const _1_ADD_3: () = _b4::<AddExp<U1, U3>>();
         const _1_ADD_4: () = _b5::<AddExp<U1, U4>>();
         const _2_ADD_2: () = _b4::<AddExp<U2, U2>>();

--- a/src/expr/add.rs
+++ b/src/expr/add.rs
@@ -42,7 +42,7 @@ impl<B> NumExpr for Add<U1, BitString<B, _0>, Base>
 where
     B: BitStrLit,
 {
-    type Ret = BitString<U1, _1>;
+    type Ret = BitString<B, _1>;
 }
 
 // ---
@@ -105,7 +105,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_res::*, U0, U1, U2, U3, U6, U7};
+    use crate::{test_res::*, U0, U1, U2, U3, U4, U6, U7};
     #[test]
     fn eval_add() {
         const _0_ADD_0: () = _b0::<Add<U0, U0>>();
@@ -115,6 +115,7 @@ mod test {
         const _1_ADD_2: () = _b3::<Add<U1, U2>>();
         const _3_ADD_1: () = _b4::<Add<U3, U1>>();
         const _1_ADD_3: () = _b4::<Add<U1, U3>>();
+        const _1_ADD_4: () = _b5::<Add<U1, U4>>();
         const _2_ADD_2: () = _b4::<Add<U2, U2>>();
         const _3_ADD_3: () = _b6::<Add<U3, U3>>();
         const _6_ADD_1: () = _b7::<Add<U6, U1>>();

--- a/src/expr/add.rs
+++ b/src/expr/add.rs
@@ -1,44 +1,44 @@
 use crate::{
-    op_types::Add,
+    op_types::AddExp,
     val_types::{BitStrLit, BitString, _0, _1},
     Base, NumExpr, NumRet, U0, U1,
 };
 
-impl<L, R> NumExpr for Add<L, R>
+impl<L, R> NumExpr for AddExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    Add<L::Ret, R::Ret, Base>: NumExpr,
+    AddExp<L::Ret, R::Ret, Base>: NumExpr,
 {
-    type Ret = NumRet<Add<L::Ret, R::Ret, Base>>;
+    type Ret = NumRet<AddExp<L::Ret, R::Ret, Base>>;
 }
 
 // ----
 //  Most basic of addition evaluations
 // ----
-impl NumExpr for Add<U0, U0, Base> {
+impl NumExpr for AddExp<U0, U0, Base> {
     type Ret = U0;
 }
-impl NumExpr for Add<U0, U1, Base> {
+impl NumExpr for AddExp<U0, U1, Base> {
     type Ret = U1;
 }
-impl NumExpr for Add<U1, U0, Base> {
+impl NumExpr for AddExp<U1, U0, Base> {
     type Ret = U1;
 }
-impl NumExpr for Add<U1, U1, Base> {
+impl NumExpr for AddExp<U1, U1, Base> {
     type Ret = BitString<U1, _0>;
 }
 
 // ---
 // Non-carry bit-additions to bit-string literal
 // ---
-impl<B> NumExpr for Add<BitString<B, _0>, U1, Base>
+impl<B> NumExpr for AddExp<BitString<B, _0>, U1, Base>
 where
     B: BitStrLit,
 {
     type Ret = BitString<B, _1>;
 }
-impl<B> NumExpr for Add<U1, BitString<B, _0>, Base>
+impl<B> NumExpr for AddExp<U1, BitString<B, _0>, Base>
 where
     B: BitStrLit,
 {
@@ -48,59 +48,59 @@ where
 // ---
 // Carrying increment to a bit-string-literal
 // ---
-impl<B> NumExpr for Add<BitString<B, _1>, U1, Base>
+impl<B> NumExpr for AddExp<BitString<B, _1>, U1, Base>
 where
     // Recurse the carry
-    Add<B, U1>: NumExpr,
+    AddExp<B, U1>: NumExpr,
     // Ensure the carry recursion is a valid progression
-    NumRet<Add<B, U1>>: BitStrLit,
+    NumRet<AddExp<B, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<B, U1>>, _0>;
+    type Ret = BitString<NumRet<AddExp<B, U1>>, _0>;
 }
 
-impl<B> NumExpr for Add<U1, BitString<B, _1>, Base>
+impl<B> NumExpr for AddExp<U1, BitString<B, _1>, Base>
 where
-    Add<B, U1>: NumExpr,
-    NumRet<Add<B, U1>>: BitStrLit,
+    AddExp<B, U1>: NumExpr,
+    NumRet<AddExp<B, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<B, U1>>, _0>;
+    type Ret = BitString<NumRet<AddExp<B, U1>>, _0>;
 }
 
 // ---
 // Addition of two bit-string literals
 // ---
 /// (LB, 0) + (RB, 0) == ((LB + RB), 0)
-impl<LB, RB> NumExpr for Add<BitString<LB, _0>, BitString<RB, _0>, Base>
+impl<LB, RB> NumExpr for AddExp<BitString<LB, _0>, BitString<RB, _0>, Base>
 where
-    Add<LB, RB>: NumExpr,
-    NumRet<Add<LB, RB>>: BitStrLit,
+    AddExp<LB, RB>: NumExpr,
+    NumRet<AddExp<LB, RB>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<LB, RB>>, _0>;
+    type Ret = BitString<NumRet<AddExp<LB, RB>>, _0>;
 }
 /// (LB, 0) + (RB, 1) == ((LB + RB), 1)
-impl<LB, RB> NumExpr for Add<BitString<LB, _0>, BitString<RB, _1>, Base>
+impl<LB, RB> NumExpr for AddExp<BitString<LB, _0>, BitString<RB, _1>, Base>
 where
-    Add<LB, RB>: NumExpr,
-    NumRet<Add<LB, RB>>: BitStrLit,
+    AddExp<LB, RB>: NumExpr,
+    NumRet<AddExp<LB, RB>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<LB, RB>>, _1>;
+    type Ret = BitString<NumRet<AddExp<LB, RB>>, _1>;
 }
-impl<LB, RB> NumExpr for Add<BitString<LB, _1>, BitString<RB, _0>, Base>
+impl<LB, RB> NumExpr for AddExp<BitString<LB, _1>, BitString<RB, _0>, Base>
 where
-    Add<LB, RB>: NumExpr,
-    NumRet<Add<LB, RB>>: BitStrLit,
+    AddExp<LB, RB>: NumExpr,
+    NumRet<AddExp<LB, RB>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<LB, RB>>, _1>;
+    type Ret = BitString<NumRet<AddExp<LB, RB>>, _1>;
 }
 /// (LB, 1) + (RB, 1) == ((LB + RB) + 1, 1)
-impl<LB, RB> NumExpr for Add<BitString<LB, _1>, BitString<RB, _1>, Base>
+impl<LB, RB> NumExpr for AddExp<BitString<LB, _1>, BitString<RB, _1>, Base>
 where
-    Add<LB, RB>: NumExpr,
-    NumRet<Add<LB, RB>>: NumExpr,
-    Add<NumRet<NumRet<Add<LB, RB>>>, U1>: NumExpr,
-    NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, U1>>: BitStrLit,
+    AddExp<LB, RB>: NumExpr,
+    NumRet<AddExp<LB, RB>>: NumExpr,
+    AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>: NumExpr,
+    NumRet<AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Add<NumRet<NumRet<Add<LB, RB>>>, U1>>, _0>;
+    type Ret = BitString<NumRet<AddExp<NumRet<NumRet<AddExp<LB, RB>>>, U1>>, _0>;
 }
 #[cfg(test)]
 mod test {
@@ -108,23 +108,23 @@ mod test {
     use crate::{test_res::*, U0, U1, U2, U3, U4, U6, U7};
     #[test]
     fn eval_add() {
-        const _0_ADD_0: () = _b0::<Add<U0, U0>>();
-        const _1_ADD_0: () = _b1::<Add<U1, U0>>();
-        const _1_ADD_1: () = _b2::<Add<U1, U1>>();
-        const _2_ADD_1: () = _b3::<Add<U2, U1>>();
-        const _1_ADD_2: () = _b3::<Add<U1, U2>>();
-        const _3_ADD_1: () = _b4::<Add<U3, U1>>();
-        const _1_ADD_3: () = _b4::<Add<U1, U3>>();
-        const _1_ADD_4: () = _b5::<Add<U1, U4>>();
-        const _2_ADD_2: () = _b4::<Add<U2, U2>>();
-        const _3_ADD_3: () = _b6::<Add<U3, U3>>();
-        const _6_ADD_1: () = _b7::<Add<U6, U1>>();
-        const _7_ADD_1: () = _b8::<Add<U7, U1>>();
+        const _0_ADD_0: () = _b0::<AddExp<U0, U0>>();
+        const _1_ADD_0: () = _b1::<AddExp<U1, U0>>();
+        const _1_ADD_1: () = _b2::<AddExp<U1, U1>>();
+        const _2_ADD_1: () = _b3::<AddExp<U2, U1>>();
+        const _1_ADD_2: () = _b3::<AddExp<U1, U2>>();
+        const _3_ADD_1: () = _b4::<AddExp<U3, U1>>();
+        const _1_ADD_3: () = _b4::<AddExp<U1, U3>>();
+        const _1_ADD_4: () = _b5::<AddExp<U1, U4>>();
+        const _2_ADD_2: () = _b4::<AddExp<U2, U2>>();
+        const _3_ADD_3: () = _b6::<AddExp<U3, U3>>();
+        const _6_ADD_1: () = _b7::<AddExp<U6, U1>>();
+        const _7_ADD_1: () = _b8::<AddExp<U7, U1>>();
 
-        const _1_ADD_1__ADD_1: () = _b3::<Add<U1, Add<U1, U1>>>();
-        const _1_ADD__1_ADD_1: () = _b3::<Add<Add<U1, U1>, U1>>();
+        const _1_ADD_1__ADD_1: () = _b3::<AddExp<U1, AddExp<U1, U1>>>();
+        const _1_ADD__1_ADD_1: () = _b3::<AddExp<AddExp<U1, U1>, U1>>();
 
-        const _3_ADD_3__ADD_3: () = _b9::<Add<U3, Add<U3, U3>>>();
-        const _3_ADD__3_ADD_3: () = _b9::<Add<Add<U3, U3>, U3>>();
+        const _3_ADD_3__ADD_3: () = _b9::<AddExp<U3, AddExp<U3, U3>>>();
+        const _3_ADD__3_ADD_3: () = _b9::<AddExp<AddExp<U3, U3>, U3>>();
     }
 }

--- a/src/expr/cmp.rs
+++ b/src/expr/cmp.rs
@@ -7,8 +7,8 @@ mod ltegte;
 #[cfg(test)]
 mod test {
     use crate::ctrl_types::{False, True, AND, GT, LT, OR};
-    use crate::test_res::*;
-    use crate::val_types::{BitString, _0, _1};
+    use crate::val_types::{_0, _1};
+    use crate::{test_res::*, U2, U3};
     #[test]
     fn eval_and() {
         const _T_AND_T: () = _t::<AND<True, True>>();
@@ -39,14 +39,14 @@ mod test {
         const _1_GT_0: () = _t::<GT<_1, _0>>();
         const _1_GT_1: () = _f::<GT<_1, _1>>();
 
-        const _2_GT_1: () = _t::<GT<BitString<_1, _0>, _1>>();
-        const _2_LT_1: () = _f::<LT<BitString<_1, _0>, _1>>();
-        const _1_GT_2: () = _f::<GT<_1, BitString<_1, _0>>>();
-        const _1_LT_2: () = _t::<LT<_1, BitString<_1, _0>>>();
+        const _2_GT_1: () = _t::<GT<U2, _1>>();
+        const _2_LT_1: () = _f::<LT<U2, _1>>();
+        const _1_GT_2: () = _f::<GT<_1, U2>>();
+        const _1_LT_2: () = _t::<LT<_1, U2>>();
 
-        const _3_GT_2: () = _t::<GT<BitString<_1, _1>, BitString<_1, _0>>>();
-        const _3_LT_2: () = _f::<LT<BitString<_1, _1>, BitString<_1, _0>>>();
-        const _2_GT_3: () = _f::<GT<BitString<_1, _0>, BitString<_1, _1>>>();
-        const _2_LT_3: () = _t::<LT<BitString<_1, _0>, BitString<_1, _1>>>();
+        const _3_GT_2: () = _t::<GT<U3, U2>>();
+        const _3_LT_2: () = _f::<LT<U3, U2>>();
+        const _2_GT_3: () = _f::<GT<U2, U3>>();
+        const _2_LT_3: () = _t::<LT<U2, U3>>();
     }
 }

--- a/src/expr/mlsb.rs
+++ b/src/expr/mlsb.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    op_types::{Add, LSB, MSB},
+    op_types::{AddExp, LSB, MSB},
     val_types::{BitLit, BitStrLit, BitString, NumberVal, _0, _1},
     NumExpr, NumRet, U0, U1,
 };
@@ -38,10 +38,10 @@ where
     Idx: NumberVal,
     BS: NumberVal + BitStrLit,
     B: BitLit,
-    Add<Idx, U1>: NumExpr,
-    MSBCount<NumRet<Add<Idx, U1>>, BS>: NumExpr,
+    AddExp<Idx, U1>: NumExpr,
+    MSBCount<NumRet<AddExp<Idx, U1>>, BS>: NumExpr,
 {
-    type Ret = NumRet<MSBCount<NumRet<Add<Idx, U1>>, BS>>;
+    type Ret = NumRet<MSBCount<NumRet<AddExp<Idx, U1>>, BS>>;
 }
 
 impl<BS> NumExpr for LSB<BS>
@@ -75,10 +75,10 @@ impl<Idx, BS> NumExpr for LSBCount<Idx, BitString<BS, _0>>
 where
     Idx: NumberVal,
     BS: NumberVal + BitStrLit,
-    Add<Idx, U1>: NumExpr,
-    LSBCount<NumRet<Add<Idx, U1>>, BS>: NumExpr,
+    AddExp<Idx, U1>: NumExpr,
+    LSBCount<NumRet<AddExp<Idx, U1>>, BS>: NumExpr,
 {
-    type Ret = NumRet<LSBCount<NumRet<Add<Idx, U1>>, BS>>;
+    type Ret = NumRet<LSBCount<NumRet<AddExp<Idx, U1>>, BS>>;
 }
 impl<Idx, BS> NumExpr for LSBCount<Idx, BitString<BS, _1>>
 where

--- a/src/expr/mlsb.rs
+++ b/src/expr/mlsb.rs
@@ -3,15 +3,15 @@ use core::marker::PhantomData;
 use crate::{
     op_types::{Add, LSB, MSB},
     val_types::{BitLit, BitStrLit, BitString, NumberVal, _0, _1},
-    NumExpr, NumRet,
+    NumExpr, NumRet, U0, U1,
 };
 
 impl<BS> NumExpr for MSB<BS>
 where
     BS: NumExpr,
-    MSBCount<_0, BS::Ret>: NumExpr,
+    MSBCount<U0, BS::Ret>: NumExpr,
 {
-    type Ret = NumRet<MSBCount<_0, BS::Ret>>;
+    type Ret = NumRet<MSBCount<U0, BS::Ret>>;
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -21,13 +21,13 @@ pub struct MSBCount<Idx: NumberVal, Bs: NumberVal> {
     // _mode: PhantomData<M>,
 }
 
-impl<Idx> NumExpr for MSBCount<Idx, _0>
+impl<Idx> NumExpr for MSBCount<Idx, U0>
 where
     Idx: NumberVal,
 {
     type Ret = Idx;
 }
-impl<Idx> NumExpr for MSBCount<Idx, _1>
+impl<Idx> NumExpr for MSBCount<Idx, U1>
 where
     Idx: NumberVal,
 {
@@ -38,18 +38,18 @@ where
     Idx: NumberVal,
     BS: NumberVal + BitStrLit,
     B: BitLit,
-    Add<Idx, _1>: NumExpr,
-    MSBCount<NumRet<Add<Idx, _1>>, BS>: NumExpr,
+    Add<Idx, U1>: NumExpr,
+    MSBCount<NumRet<Add<Idx, U1>>, BS>: NumExpr,
 {
-    type Ret = NumRet<MSBCount<NumRet<Add<Idx, _1>>, BS>>;
+    type Ret = NumRet<MSBCount<NumRet<Add<Idx, U1>>, BS>>;
 }
 
 impl<BS> NumExpr for LSB<BS>
 where
     BS: NumExpr,
-    LSBCount<_0, BS::Ret>: NumExpr,
+    LSBCount<U0, BS::Ret>: NumExpr,
 {
-    type Ret = NumRet<LSBCount<_0, BS::Ret>>;
+    type Ret = NumRet<LSBCount<U0, BS::Ret>>;
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -59,13 +59,13 @@ pub struct LSBCount<Idx: NumberVal, Bs: NumberVal> {
     // _mode: PhantomData<M>,
 }
 
-impl<Idx> NumExpr for LSBCount<Idx, _0>
+impl<Idx> NumExpr for LSBCount<Idx, U0>
 where
     Idx: NumberVal,
 {
     type Ret = Idx;
 }
-impl<Idx> NumExpr for LSBCount<Idx, _1>
+impl<Idx> NumExpr for LSBCount<Idx, U1>
 where
     Idx: NumberVal,
 {
@@ -75,10 +75,10 @@ impl<Idx, BS> NumExpr for LSBCount<Idx, BitString<BS, _0>>
 where
     Idx: NumberVal,
     BS: NumberVal + BitStrLit,
-    Add<Idx, _1>: NumExpr,
-    LSBCount<NumRet<Add<Idx, _1>>, BS>: NumExpr,
+    Add<Idx, U1>: NumExpr,
+    LSBCount<NumRet<Add<Idx, U1>>, BS>: NumExpr,
 {
-    type Ret = NumRet<LSBCount<NumRet<Add<Idx, _1>>, BS>>;
+    type Ret = NumRet<LSBCount<NumRet<Add<Idx, U1>>, BS>>;
 }
 impl<Idx, BS> NumExpr for LSBCount<Idx, BitString<BS, _1>>
 where

--- a/src/expr/mul.rs
+++ b/src/expr/mul.rs
@@ -1,7 +1,7 @@
 use crate::{
     op_types::{Add, Mul},
     val_types::{BitLit, BitStrLit, BitString, NumberVal, _0, _1},
-    Base, NumExpr, NumRet,
+    Base, NumExpr, NumRet, U0, U1,
 };
 
 impl<L, R> NumExpr for Mul<L, R>
@@ -17,19 +17,19 @@ where
 // Past attempts to coallesce these impls resulted in overlapping-impl headaches
 // -------------
 
-impl NumExpr for Mul<_0, _1, Base> {
-    type Ret = _0;
+impl NumExpr for Mul<U0, U1, Base> {
+    type Ret = U0;
 }
-impl NumExpr for Mul<_1, _0, Base> {
-    type Ret = _0;
+impl NumExpr for Mul<U1, U0, Base> {
+    type Ret = U0;
 }
-impl NumExpr for Mul<_0, _0, Base> {
-    type Ret = _0;
+impl NumExpr for Mul<U0, U0, Base> {
+    type Ret = U0;
 }
-impl NumExpr for Mul<_1, _1, Base> {
-    type Ret = _1;
+impl NumExpr for Mul<U1, U1, Base> {
+    type Ret = U1;
 }
-impl<Bs, B> NumExpr for Mul<_1, BitString<Bs, B>, Base>
+impl<Bs, B> NumExpr for Mul<U1, BitString<Bs, B>, Base>
 where
     Bs: NumExpr,
     B: BitLit,
@@ -38,7 +38,7 @@ where
     type Ret = BitString<Bs, B>;
 }
 
-// (LB, _1) * Val == ((LB * Val), _0) + Val
+// (LB, U1) * Val == ((LB * Val), U0) + Val
 impl<LB, Val> NumExpr for Mul<BitString<LB, _1>, Val, Base>
 where
     LB: BitStrLit,
@@ -47,7 +47,7 @@ where
 {
     type Ret = NumRet<Add<BitString<NumRet<Mul<LB, Val>>, _0>, Val>>;
 }
-// (LB, _0) * Val == ((LB * Val), _0)
+// (LB, U0) * Val == ((LB * Val), U0)
 impl<LB, Val> NumExpr for Mul<BitString<LB, _0>, Val, Base>
 where
     LB: BitStrLit,
@@ -60,27 +60,25 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_res::*;
+    use crate::{test_res::*, U1, U2, U3, U4, U5, U6, U7, U8};
     #[test]
     fn eval_add() {
-        const _0_MUL_0: () = _b0::<Mul<_0, _0>>();
-        const _0_MUL_1: () = _b0::<Mul<_0, _1>>();
-        const _1_MUL_0: () = _b0::<Mul<_1, _0>>();
-        const _2_MUL_1: () = _b2::<Mul<BitString<_1, _0>, _1>>();
-        const _1_MUL_2: () = _b2::<Mul<_1, BitString<_1, _0>>>();
-        const _3_MUL_1: () = _b3::<Mul<BitString<_1, _1>, _1>>();
-        const _1_MUL_3: () = _b3::<Mul<_1, BitString<_1, _1>>>();
-        const _2_MUL_2: () = _b4::<Mul<BitString<_1, _0>, BitString<_1, _0>>>();
-        const _4_MUL_1: () = _b4::<Mul<BitString<BitString<_1, _0>, _0>, _1>>();
-        const _5_MUL_1: () = _b5::<Mul<BitString<BitString<_1, _0>, _1>, _1>>();
-        const _6_MUL_1: () = _b6::<Mul<BitString<BitString<_1, _1>, _0>, _1>>();
-        const _7_MUL_1: () = _b7::<Mul<BitString<BitString<_1, _1>, _1>, _1>>();
-        const _8_MUL_1: () = _b8::<Mul<BitString<BitString<BitString<_1, _0>, _0>, _0>, _1>>();
-        const _3_MUL_3: () = _b9::<Mul<BitString<_1, _1>, BitString<_1, _1>>>();
+        const _0_MUL_0: () = _b0::<Mul<U0, U0>>();
+        const _0_MUL_1: () = _b0::<Mul<U0, U1>>();
+        const _1_MUL_0: () = _b0::<Mul<U1, U0>>();
+        const _2_MUL_1: () = _b2::<Mul<U2, U1>>();
+        const _1_MUL_2: () = _b2::<Mul<U1, U2>>();
+        const _3_MUL_1: () = _b3::<Mul<U3, U1>>();
+        const _1_MUL_3: () = _b3::<Mul<U1, U3>>();
+        const _2_MUL_2: () = _b4::<Mul<U2, U2>>();
+        const _4_MUL_1: () = _b4::<Mul<U4, U1>>();
+        const _5_MUL_1: () = _b5::<Mul<U5, U1>>();
+        const _6_MUL_1: () = _b6::<Mul<U6, U1>>();
+        const _7_MUL_1: () = _b7::<Mul<U7, U1>>();
+        const _8_MUL_1: () = _b8::<Mul<U8, U1>>();
+        const _3_MUL_3: () = _b9::<Mul<U3, U3>>();
 
-        const _2_MUL_2__MUL_2: () =
-            _b8::<Mul<Mul<BitString<_1, _0>, BitString<_1, _0>>, BitString<_1, _0>>>();
-        const _2_MUL__2_MUL_2: () =
-            _b8::<Mul<BitString<_1, _0>, Mul<BitString<_1, _0>, BitString<_1, _0>>>>();
+        const _2_MUL_2__MUL_2: () = _b8::<Mul<Mul<U2, U2>, U2>>();
+        const _2_MUL__2_MUL_2: () = _b8::<Mul<U2, Mul<U2, U2>>>();
     }
 }

--- a/src/expr/mul.rs
+++ b/src/expr/mul.rs
@@ -1,35 +1,35 @@
 use crate::{
-    op_types::{Add, Mul},
+    op_types::{AddExp, MulExp},
     val_types::{BitLit, BitStrLit, BitString, NumberVal, _0, _1},
     Base, NumExpr, NumRet, U0, U1,
 };
 
-impl<L, R> NumExpr for Mul<L, R>
+impl<L, R> NumExpr for MulExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    Mul<L::Ret, R::Ret, Base>: NumExpr,
+    MulExp<L::Ret, R::Ret, Base>: NumExpr,
 {
-    type Ret = NumRet<Mul<L::Ret, R::Ret, Base>>;
+    type Ret = NumRet<MulExp<L::Ret, R::Ret, Base>>;
 }
 // -------------
 // Hard codod base cases.
 // Past attempts to coallesce these impls resulted in overlapping-impl headaches
 // -------------
 
-impl NumExpr for Mul<U0, U1, Base> {
+impl NumExpr for MulExp<U0, U1, Base> {
     type Ret = U0;
 }
-impl NumExpr for Mul<U1, U0, Base> {
+impl NumExpr for MulExp<U1, U0, Base> {
     type Ret = U0;
 }
-impl NumExpr for Mul<U0, U0, Base> {
+impl NumExpr for MulExp<U0, U0, Base> {
     type Ret = U0;
 }
-impl NumExpr for Mul<U1, U1, Base> {
+impl NumExpr for MulExp<U1, U1, Base> {
     type Ret = U1;
 }
-impl<Bs, B> NumExpr for Mul<U1, BitString<Bs, B>, Base>
+impl<Bs, B> NumExpr for MulExp<U1, BitString<Bs, B>, Base>
 where
     Bs: NumExpr,
     B: BitLit,
@@ -39,22 +39,22 @@ where
 }
 
 // (LB, U1) * Val == ((LB * Val), U0) + Val
-impl<LB, Val> NumExpr for Mul<BitString<LB, _1>, Val, Base>
+impl<LB, Val> NumExpr for MulExp<BitString<LB, _1>, Val, Base>
 where
     LB: BitStrLit,
-    Mul<LB, Val>: NumExpr,
-    Add<BitString<NumRet<Mul<LB, Val>>, _0>, Val>: NumExpr,
+    MulExp<LB, Val>: NumExpr,
+    AddExp<BitString<NumRet<MulExp<LB, Val>>, _0>, Val>: NumExpr,
 {
-    type Ret = NumRet<Add<BitString<NumRet<Mul<LB, Val>>, _0>, Val>>;
+    type Ret = NumRet<AddExp<BitString<NumRet<MulExp<LB, Val>>, _0>, Val>>;
 }
 // (LB, U0) * Val == ((LB * Val), U0)
-impl<LB, Val> NumExpr for Mul<BitString<LB, _0>, Val, Base>
+impl<LB, Val> NumExpr for MulExp<BitString<LB, _0>, Val, Base>
 where
     LB: BitStrLit,
-    Mul<LB, Val>: NumExpr,
-    NumRet<Mul<LB, Val>>: BitStrLit,
+    MulExp<LB, Val>: NumExpr,
+    NumRet<MulExp<LB, Val>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Mul<LB, Val>>, _0>;
+    type Ret = BitString<NumRet<MulExp<LB, Val>>, _0>;
 }
 
 #[cfg(test)]
@@ -63,22 +63,22 @@ mod test {
     use crate::{test_res::*, U1, U2, U3, U4, U5, U6, U7, U8};
     #[test]
     fn eval_add() {
-        const _0_MUL_0: () = _b0::<Mul<U0, U0>>();
-        const _0_MUL_1: () = _b0::<Mul<U0, U1>>();
-        const _1_MUL_0: () = _b0::<Mul<U1, U0>>();
-        const _2_MUL_1: () = _b2::<Mul<U2, U1>>();
-        const _1_MUL_2: () = _b2::<Mul<U1, U2>>();
-        const _3_MUL_1: () = _b3::<Mul<U3, U1>>();
-        const _1_MUL_3: () = _b3::<Mul<U1, U3>>();
-        const _2_MUL_2: () = _b4::<Mul<U2, U2>>();
-        const _4_MUL_1: () = _b4::<Mul<U4, U1>>();
-        const _5_MUL_1: () = _b5::<Mul<U5, U1>>();
-        const _6_MUL_1: () = _b6::<Mul<U6, U1>>();
-        const _7_MUL_1: () = _b7::<Mul<U7, U1>>();
-        const _8_MUL_1: () = _b8::<Mul<U8, U1>>();
-        const _3_MUL_3: () = _b9::<Mul<U3, U3>>();
+        const _0_MUL_0: () = _b0::<MulExp<U0, U0>>();
+        const _0_MUL_1: () = _b0::<MulExp<U0, U1>>();
+        const _1_MUL_0: () = _b0::<MulExp<U1, U0>>();
+        const _2_MUL_1: () = _b2::<MulExp<U2, U1>>();
+        const _1_MUL_2: () = _b2::<MulExp<U1, U2>>();
+        const _3_MUL_1: () = _b3::<MulExp<U3, U1>>();
+        const _1_MUL_3: () = _b3::<MulExp<U1, U3>>();
+        const _2_MUL_2: () = _b4::<MulExp<U2, U2>>();
+        const _4_MUL_1: () = _b4::<MulExp<U4, U1>>();
+        const _5_MUL_1: () = _b5::<MulExp<U5, U1>>();
+        const _6_MUL_1: () = _b6::<MulExp<U6, U1>>();
+        const _7_MUL_1: () = _b7::<MulExp<U7, U1>>();
+        const _8_MUL_1: () = _b8::<MulExp<U8, U1>>();
+        const _3_MUL_3: () = _b9::<MulExp<U3, U3>>();
 
-        const _2_MUL_2__MUL_2: () = _b8::<Mul<Mul<U2, U2>, U2>>();
-        const _2_MUL__2_MUL_2: () = _b8::<Mul<U2, Mul<U2, U2>>>();
+        const _2_MUL_2__MUL_2: () = _b8::<MulExp<MulExp<U2, U2>, U2>>();
+        const _2_MUL__2_MUL_2: () = _b8::<MulExp<U2, MulExp<U2, U2>>>();
     }
 }

--- a/src/expr/shlr.rs
+++ b/src/expr/shlr.rs
@@ -1,58 +1,58 @@
 use crate::{
-    op_types::{ShL, ShR, Sub},
+    op_types::{ShLExp, ShRExp, SubExp},
     val_types::{BitStrLit, BitString, NumberVal, _0, _1},
     Base, NumExpr, NumRet, U1,
 };
 
-impl<L, R> NumExpr for ShL<L, R>
+impl<L, R> NumExpr for ShLExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    ShL<L::Ret, R::Ret, Base>: NumExpr,
+    ShLExp<L::Ret, R::Ret, Base>: NumExpr,
 {
-    type Ret = NumRet<ShL<L::Ret, R::Ret, Base>>;
+    type Ret = NumRet<ShLExp<L::Ret, R::Ret, Base>>;
 }
 
-impl<B> NumExpr for ShL<B, _0, Base>
+impl<B> NumExpr for ShLExp<B, _0, Base>
 where
     B: NumberVal,
 {
     type Ret = B;
 }
-impl<B, N> NumExpr for ShL<B, N, Base>
+impl<B, N> NumExpr for ShLExp<B, N, Base>
 where
     B: BitStrLit,
-    Sub<N, _1>: NumExpr,
-    ShL<BitString<B, _0>, NumRet<Sub<N, _1>>>: NumExpr,
+    SubExp<N, _1>: NumExpr,
+    ShLExp<BitString<B, _0>, NumRet<SubExp<N, _1>>>: NumExpr,
 {
-    type Ret = NumRet<ShL<BitString<B, _0>, NumRet<Sub<N, _1>>>>;
+    type Ret = NumRet<ShLExp<BitString<B, _0>, NumRet<SubExp<N, _1>>>>;
 }
-impl<L, R> NumExpr for ShR<L, R>
+impl<L, R> NumExpr for ShRExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    ShR<L::Ret, R::Ret, Base>: NumExpr,
+    ShRExp<L::Ret, R::Ret, Base>: NumExpr,
 {
-    type Ret = NumRet<ShR<L::Ret, R::Ret, Base>>;
+    type Ret = NumRet<ShRExp<L::Ret, R::Ret, Base>>;
 }
 
-impl<B> NumExpr for ShR<B, _0, Base>
+impl<B> NumExpr for ShRExp<B, _0, Base>
 where
     B: NumberVal,
 {
     type Ret = B;
 }
-impl<Bs, B, N> NumExpr for ShR<BitString<Bs, B>, N, Base>
+impl<Bs, B, N> NumExpr for ShRExp<BitString<Bs, B>, N, Base>
 where
     Bs: NumExpr,
-    Sub<N, _1>: NumExpr,
-    ShR<Bs::Ret, NumRet<Sub<N, _1>>, Base>: NumExpr,
+    SubExp<N, _1>: NumExpr,
+    ShRExp<Bs::Ret, NumRet<SubExp<N, _1>>, Base>: NumExpr,
 {
-    type Ret = NumRet<ShR<Bs::Ret, NumRet<Sub<N, _1>>, Base>>;
+    type Ret = NumRet<ShRExp<Bs::Ret, NumRet<SubExp<N, _1>>, Base>>;
 }
-impl<N> NumExpr for ShR<U1, N, Base>
+impl<N> NumExpr for ShRExp<U1, N, Base>
 where
-    Sub<N, _1>: NumExpr,
+    SubExp<N, _1>: NumExpr,
 {
     type Ret = _0;
 }
@@ -64,21 +64,21 @@ mod test {
     #[allow(non_upper_case_globals)]
     #[test]
     fn eval_msb() {
-        const _0_ShL_0: () = _b0::<ShL<_0, U0>>();
-        const _1_ShL_0: () = _b1::<ShL<_1, U0>>();
-        const _1_ShL_1: () = _b2::<ShL<_1, U1>>();
-        const _1_ShR_1: () = _b0::<ShR<_1, U1>>();
-        const _1_ShR_0: () = _b1::<ShR<_1, U0>>();
+        const _0_ShL_0: () = _b0::<ShLExp<_0, U0>>();
+        const _1_ShL_0: () = _b1::<ShLExp<_1, U0>>();
+        const _1_ShL_1: () = _b2::<ShLExp<_1, U1>>();
+        const _1_ShR_1: () = _b0::<ShRExp<_1, U1>>();
+        const _1_ShR_0: () = _b1::<ShRExp<_1, U0>>();
 
-        const _10_ShR_0: () = _b2::<ShR<BitString<_1, _0>, U0>>();
-        const _11_ShR_0: () = _b3::<ShR<BitString<_1, _1>, U0>>();
-        const _10_ShR_1: () = _b1::<ShR<BitString<_1, _0>, U1>>();
-        const _11_ShR_1: () = _b1::<ShR<BitString<_1, _1>, U1>>();
+        const _10_ShR_0: () = _b2::<ShRExp<BitString<_1, _0>, U0>>();
+        const _11_ShR_0: () = _b3::<ShRExp<BitString<_1, _1>, U0>>();
+        const _10_ShR_1: () = _b1::<ShRExp<BitString<_1, _0>, U1>>();
+        const _11_ShR_1: () = _b1::<ShRExp<BitString<_1, _1>, U1>>();
 
-        const _1_ShL_2: () = _b1::<ShL<_1, U0>>();
-        const _1_ShL_3: () = _b2::<ShL<_1, U1>>();
-        const _3_ShR_2: () = _b0::<ShR<U3, U2>>();
-        const _9_ShR_3: () = _b1::<ShR<U9, U3>>();
+        const _1_ShL_2: () = _b1::<ShLExp<_1, U0>>();
+        const _1_ShL_3: () = _b2::<ShLExp<_1, U1>>();
+        const _3_ShR_2: () = _b0::<ShRExp<U3, U2>>();
+        const _9_ShR_3: () = _b1::<ShRExp<U9, U3>>();
         // const _MSB_10: () = _b1::<MSB<BitString<_1, _0>>>();
         // const _MSB_11: () = _b1::<MSB<BitString<_1, _1>>>();
         // const _MSB_100: () = _b1::<MSB<BitString<BitString<_1, _0>, _1>>>();

--- a/src/expr/shlr.rs
+++ b/src/expr/shlr.rs
@@ -1,7 +1,7 @@
 use crate::{
     op_types::{ShL, ShR, Sub},
     val_types::{BitStrLit, BitString, NumberVal, _0, _1},
-    Base, NumExpr, NumRet,
+    Base, NumExpr, NumRet, U1,
 };
 
 impl<L, R> NumExpr for ShL<L, R>
@@ -50,7 +50,7 @@ where
 {
     type Ret = NumRet<ShR<Bs::Ret, NumRet<Sub<N, _1>>, Base>>;
 }
-impl<N> NumExpr for ShR<_1, N, Base>
+impl<N> NumExpr for ShR<U1, N, Base>
 where
     Sub<N, _1>: NumExpr,
 {
@@ -60,26 +60,25 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_res::*;
+    use crate::{test_res::*, U0, U1, U2, U3, U9};
     #[allow(non_upper_case_globals)]
     #[test]
     fn eval_msb() {
-        const _0_ShL_0: () = _b0::<ShL<_0, _0>>();
-        const _1_ShL_0: () = _b1::<ShL<_1, _0>>();
-        const _1_ShL_1: () = _b2::<ShL<_1, _1>>();
-        const _1_ShR_1: () = _b0::<ShR<_1, _1>>();
-        const _1_ShR_0: () = _b1::<ShR<_1, _0>>();
+        const _0_ShL_0: () = _b0::<ShL<_0, U0>>();
+        const _1_ShL_0: () = _b1::<ShL<_1, U0>>();
+        const _1_ShL_1: () = _b2::<ShL<_1, U1>>();
+        const _1_ShR_1: () = _b0::<ShR<_1, U1>>();
+        const _1_ShR_0: () = _b1::<ShR<_1, U0>>();
 
-        const _10_ShR_0: () = _b2::<ShR<BitString<_1, _0>, _0>>();
-        const _11_ShR_0: () = _b3::<ShR<BitString<_1, _1>, _0>>();
-        const _10_ShR_1: () = _b1::<ShR<BitString<_1, _0>, _1>>();
-        const _11_ShR_1: () = _b1::<ShR<BitString<_1, _1>, _1>>();
+        const _10_ShR_0: () = _b2::<ShR<BitString<_1, _0>, U0>>();
+        const _11_ShR_0: () = _b3::<ShR<BitString<_1, _1>, U0>>();
+        const _10_ShR_1: () = _b1::<ShR<BitString<_1, _0>, U1>>();
+        const _11_ShR_1: () = _b1::<ShR<BitString<_1, _1>, U1>>();
 
-        const _1_ShL_2: () = _b1::<ShL<_1, _0>>();
-        const _1_ShL_3: () = _b2::<ShL<_1, _1>>();
-        const _3_ShR_2: () = _b0::<ShR<BitString<_1, _1>, BitString<_1, _0>>>();
-        const _9_ShR_3: () =
-            _b1::<ShR<BitString<BitString<BitString<_1, _0>, _0>, _1>, BitString<_1, _1>>>();
+        const _1_ShL_2: () = _b1::<ShL<_1, U0>>();
+        const _1_ShL_3: () = _b2::<ShL<_1, U1>>();
+        const _3_ShR_2: () = _b0::<ShR<U3, U2>>();
+        const _9_ShR_3: () = _b1::<ShR<U9, U3>>();
         // const _MSB_10: () = _b1::<MSB<BitString<_1, _0>>>();
         // const _MSB_11: () = _b1::<MSB<BitString<_1, _1>>>();
         // const _MSB_100: () = _b1::<MSB<BitString<BitString<_1, _0>, _1>>>();

--- a/src/expr/sub.rs
+++ b/src/expr/sub.rs
@@ -1,7 +1,7 @@
 use crate::{
     op_types::Sub,
     val_types::{BitStrLit, BitString, _0, _1},
-    Base, NumExpr, NumRet,
+    Base, NumExpr, NumRet, U1,
 };
 
 impl<L, R> NumExpr for Sub<L, R>
@@ -19,15 +19,15 @@ where
 impl NumExpr for Sub<_0, _0, Base> {
     type Ret = _0;
 }
-impl NumExpr for Sub<_1, _0, Base> {
-    type Ret = _1;
+impl NumExpr for Sub<U1, _0, Base> {
+    type Ret = U1;
 }
-impl NumExpr for Sub<_1, _1, Base> {
+impl NumExpr for Sub<U1, U1, Base> {
     type Ret = _0;
 }
 // Commented out as we are not yet handling negatives
-// impl Expr for Sub<_0, _1, Base> {
-//     type Ret = _1;
+// impl Expr for Sub<_0, U1, Base> {
+//     type Ret = U1;
 // }
 
 // ---
@@ -97,18 +97,19 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_res::*;
+    use crate::{test_res::*, U0, U1, U2, U3};
     #[test]
     fn eval_add() {
-        const _0_SUB_0: () = _b0::<Sub<_0, _0>>();
-        const _1_SUB_0: () = _b1::<Sub<_1, _0>>();
-        const _1_SUB_1: () = _b0::<Sub<_1, _1>>();
-        const _2_SUB_1: () = _b1::<Sub<BitString<_1, _0>, _1>>();
+        const _0_SUB_0: () = _b0::<Sub<U0, U0>>();
+        const _1_SUB_0: () = _b1::<Sub<U1, U0>>();
+        const _1_SUB_1: () = _b0::<Sub<U1, U1>>();
+        const _2_SUB_1: () = _b1::<Sub<U2, U1>>();
         // const _1_SUB_2: () = _b3::<Sub<_1, BitString<_1, _0>>>();
-        const _3_SUB_1: () = _b2::<Sub<BitString<_1, _1>, _1>>();
+        const _3_SUB_1: () = _b2::<Sub<U3, _1>>();
+        // const _4_SUB_1: () = _b3::<Sub<U4, _1>>();
         // const _1_SUB_3: () = _b4::<Sub<_1, BitString<_1, _1>>>();
-        const _2_SUB_2: () = _b0::<Sub<BitString<_1, _0>, BitString<_1, _0>>>();
-        const _3_SUB_2: () = _b1::<Sub<BitString<_1, _1>, BitString<_1, _0>>>();
-        const _3_SUB_3: () = _b0::<Sub<BitString<_1, _1>, BitString<_1, _1>>>();
+        const _2_SUB_2: () = _b0::<Sub<U2, U2>>();
+        const _3_SUB_2: () = _b1::<Sub<U3, U2>>();
+        const _3_SUB_3: () = _b0::<Sub<U3, U3>>();
     }
 }

--- a/src/expr/sub.rs
+++ b/src/expr/sub.rs
@@ -1,29 +1,44 @@
 use crate::{
     op_types::SubExp,
-    val_types::{BitStrLit, BitString, _0, _1},
-    Base, NumExpr, NumRet, U1,
+    val_types::{BitString, NumberVal, _0, _1},
+    NumExpr, NumRet, U0, U1,
 };
+use core::ops::Sub as StSub;
 
 impl<L, R> NumExpr for SubExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    SubExp<L::Ret, R::Ret, Base>: NumExpr,
+    L::Ret: StSub<R::Ret>,
+    SubOut<L::Ret, R::Ret>: NumExpr,
+    NumRet<SubOut<L::Ret, R::Ret>>: NumberVal,
 {
-    type Ret = <SubExp<L::Ret, R::Ret, Base> as NumExpr>::Ret;
+    type Ret = NumRet<SubOut<L::Ret, R::Ret>>;
 }
+
+type SubOut<L, R> = <L as StSub<R>>::Output;
 
 // ----
 //  Most basic of subtraction evaluations
 // ----
-impl NumExpr for SubExp<_0, _0, Base> {
-    type Ret = _0;
+impl StSub<U0> for U0 {
+    type Output = U0;
+
+    fn sub(self, _rhs: U0) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl NumExpr for SubExp<U1, _0, Base> {
-    type Ret = U1;
+impl StSub<U0> for U1 {
+    type Output = U1;
+    fn sub(self, _rhs: U0) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
-impl NumExpr for SubExp<U1, U1, Base> {
-    type Ret = _0;
+impl StSub<U1> for U1 {
+    type Output = U0;
+    fn sub(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 // Commented out as we are not yet handling negatives
 // impl Expr for Sub<_0, U1, Base> {
@@ -33,9 +48,12 @@ impl NumExpr for SubExp<U1, U1, Base> {
 // ---
 // Hard-codeable trimmed decrement
 // ---
-impl NumExpr for SubExp<BitString<_1, _0>, _1, Base> {
-    type Ret = _1;
-}
+// impl StSub<_1> for BitString<_1, _0> {
+//     type Output = U1;
+//     fn sub(self, _rhs: U1) -> Self::Output {
+//         unimplemented!("type eval only")
+//     }
+// }
 
 // Commented out as we are not yet handling negatives
 // impl Expr for Sub<_1, BitString<_1, _0>, Base> {
@@ -43,55 +61,79 @@ impl NumExpr for SubExp<BitString<_1, _0>, _1, Base> {
 // }
 
 /// Non-trimming decrement
-impl<B> NumExpr for SubExp<BitString<B, _1>, _1, Base>
-where
-    B: NumExpr,
-    NumRet<B>: BitStrLit,
-{
-    type Ret = BitString<B::Ret, _0>;
+impl<B> StSub<_1> for BitString<B, _1> {
+    type Output = BitString<B, _0>;
+    fn sub(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
+impl<B> StSub<_1> for BitString<B, _0>
+where
+    B: StSub<_1>,
+    BitString<SubOut<B, _1>, _1>: NumExpr,
+{
+    type Output = NumRet<BitString<SubOut<B, _1>, _1>>;
+    fn sub(self, _rhs: U1) -> Self::Output {
+        unimplemented!("type eval only")
+    }
+}
 /// (L)0 - (R)0 = (L - R)0
-impl<LB, RB> NumExpr for SubExp<BitString<LB, _0>, BitString<RB, _0>, Base>
+impl<LB, RB> StSub<BitString<RB, _0>> for BitString<LB, _0>
 where
     // `L - R` is valid
-    SubExp<LB, RB>: NumExpr,
+    LB: StSub<RB>,
     // `(L - R)0` is valid as a bitstring
-    BitString<NumRet<SubExp<LB, RB>>, _0>: NumExpr,
+    BitString<SubOut<LB, RB>, _0>: NumExpr,
 {
-    type Ret = NumRet<BitString<NumRet<SubExp<LB, RB>>, _0>>;
+    type Output = NumRet<BitString<SubOut<LB, RB>, _0>>;
+    fn sub(self, _rhs: BitString<RB, _0>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 /// (L)0 - (R)1 = ((L - R) - 1)1
-impl<LB, RB> NumExpr for SubExp<BitString<LB, _0>, BitString<RB, _1>, Base>
+impl<LB, RB> StSub<BitString<RB, _1>> for BitString<LB, _0>
 where
     // `L - R` is valid
-    SubExp<LB, RB>: NumExpr,
+    LB: StSub<RB>,
     // `(L - R) - 1` is a valid expression
-    SubExp<NumRet<SubExp<LB, RB>>, _1>: NumExpr,
+    SubOut<LB, RB>: StSub<_1>,
     // `(L - R) - 1` Is a valid bit-string literal so can be appended with a bit to make a valid
     // number
-    NumRet<SubExp<NumRet<SubExp<LB, RB>>, _1>>: BitStrLit,
+    BitString<SubOut<SubOut<LB, RB>, _1>, _1>: NumExpr,
 {
-    type Ret = BitString<NumRet<SubExp<NumRet<SubExp<LB, RB>>, _1>>, _1>;
+    type Output = NumRet<BitString<SubOut<SubOut<LB, RB>, _1>, _1>>;
+    fn sub(self, _rhs: BitString<RB, _1>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 /// (L)1 - (R)0 = (L - R)1
-impl<LB, RB> NumExpr for SubExp<BitString<LB, _1>, BitString<RB, _0>, Base>
+impl<LB, RB> StSub<BitString<RB, _0>> for BitString<LB, _1>
 where
     // `L - R` is valid
-    SubExp<LB, RB>: NumExpr,
+    LB: StSub<RB>,
+    BitString<SubOut<LB, RB>, _1>: NumExpr,
     // `(L - R)1` is valid as a bitstring
-    BitString<NumRet<SubExp<LB, RB>>, _1>: NumExpr,
+    // BitString<NumRet<SubExp<LB, RB>>, _1>: NumExpr,
 {
-    type Ret = NumRet<BitString<NumRet<SubExp<LB, RB>>, _1>>;
+    type Output = NumRet<BitString<SubOut<LB, RB>, _1>>;
+    fn sub(self, _rhs: BitString<RB, _0>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
 /// (L)1 - (R)1 = (L - R)0
-impl<LB, RB> NumExpr for SubExp<BitString<LB, _1>, BitString<RB, _1>, Base>
+impl<LB, RB> StSub<BitString<RB, _1>> for BitString<LB, _1>
 where
-    // same operation as (L)0 - (R)0
-    SubExp<BitString<LB, _0>, BitString<RB, _0>>: NumExpr,
+    // `L - R` is valid
+    LB: StSub<RB>,
+    // `(L - R)0` is valid as a bitstring
+    BitString<SubOut<LB, RB>, _0>: NumExpr,
 {
-    type Ret = NumRet<SubExp<BitString<LB, _0>, BitString<RB, _0>>>;
+    type Output = NumRet<BitString<SubOut<LB, RB>, _0>>;
+    fn sub(self, _rhs: BitString<RB, _1>) -> Self::Output {
+        unimplemented!("type eval only")
+    }
 }
 
 #[cfg(test)]
@@ -104,10 +146,10 @@ mod test {
         const _1_SUB_0: () = _b1::<SubExp<U1, U0>>();
         const _1_SUB_1: () = _b0::<SubExp<U1, U1>>();
         const _2_SUB_1: () = _b1::<SubExp<U2, U1>>();
-        // const _1_SUB_2: () = _b3::<Sub<_1, BitString<_1, _0>>>();
+        // const _1_SUB_2: () = _b3::<SubExp<_1, BitString<_1, _0>>>();
         const _3_SUB_1: () = _b2::<SubExp<U3, _1>>();
-        // const _4_SUB_1: () = _b3::<Sub<U4, _1>>();
-        // const _1_SUB_3: () = _b4::<Sub<_1, BitString<_1, _1>>>();
+        const _4_SUB_1: () = _b3::<SubExp<BitString<BitString<_1, _0>, _0>, _1>>();
+        // const _1_SUB_3: () = _b4::<SubExp<_1, BitString<_1, _1>>>();
         const _2_SUB_2: () = _b0::<SubExp<U2, U2>>();
         const _3_SUB_2: () = _b1::<SubExp<U3, U2>>();
         const _3_SUB_3: () = _b0::<SubExp<U3, U3>>();

--- a/src/expr/sub.rs
+++ b/src/expr/sub.rs
@@ -1,28 +1,28 @@
 use crate::{
-    op_types::Sub,
+    op_types::SubExp,
     val_types::{BitStrLit, BitString, _0, _1},
     Base, NumExpr, NumRet, U1,
 };
 
-impl<L, R> NumExpr for Sub<L, R>
+impl<L, R> NumExpr for SubExp<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    Sub<L::Ret, R::Ret, Base>: NumExpr,
+    SubExp<L::Ret, R::Ret, Base>: NumExpr,
 {
-    type Ret = <Sub<L::Ret, R::Ret, Base> as NumExpr>::Ret;
+    type Ret = <SubExp<L::Ret, R::Ret, Base> as NumExpr>::Ret;
 }
 
 // ----
 //  Most basic of subtraction evaluations
 // ----
-impl NumExpr for Sub<_0, _0, Base> {
+impl NumExpr for SubExp<_0, _0, Base> {
     type Ret = _0;
 }
-impl NumExpr for Sub<U1, _0, Base> {
+impl NumExpr for SubExp<U1, _0, Base> {
     type Ret = U1;
 }
-impl NumExpr for Sub<U1, U1, Base> {
+impl NumExpr for SubExp<U1, U1, Base> {
     type Ret = _0;
 }
 // Commented out as we are not yet handling negatives
@@ -33,7 +33,7 @@ impl NumExpr for Sub<U1, U1, Base> {
 // ---
 // Hard-codeable trimmed decrement
 // ---
-impl NumExpr for Sub<BitString<_1, _0>, _1, Base> {
+impl NumExpr for SubExp<BitString<_1, _0>, _1, Base> {
     type Ret = _1;
 }
 
@@ -43,7 +43,7 @@ impl NumExpr for Sub<BitString<_1, _0>, _1, Base> {
 // }
 
 /// Non-trimming decrement
-impl<B> NumExpr for Sub<BitString<B, _1>, _1, Base>
+impl<B> NumExpr for SubExp<BitString<B, _1>, _1, Base>
 where
     B: NumExpr,
     NumRet<B>: BitStrLit,
@@ -52,46 +52,46 @@ where
 }
 
 /// (L)0 - (R)0 = (L - R)0
-impl<LB, RB> NumExpr for Sub<BitString<LB, _0>, BitString<RB, _0>, Base>
+impl<LB, RB> NumExpr for SubExp<BitString<LB, _0>, BitString<RB, _0>, Base>
 where
     // `L - R` is valid
-    Sub<LB, RB>: NumExpr,
+    SubExp<LB, RB>: NumExpr,
     // `(L - R)0` is valid as a bitstring
-    BitString<NumRet<Sub<LB, RB>>, _0>: NumExpr,
+    BitString<NumRet<SubExp<LB, RB>>, _0>: NumExpr,
 {
-    type Ret = NumRet<BitString<NumRet<Sub<LB, RB>>, _0>>;
+    type Ret = NumRet<BitString<NumRet<SubExp<LB, RB>>, _0>>;
 }
 /// (L)0 - (R)1 = ((L - R) - 1)1
-impl<LB, RB> NumExpr for Sub<BitString<LB, _0>, BitString<RB, _1>, Base>
+impl<LB, RB> NumExpr for SubExp<BitString<LB, _0>, BitString<RB, _1>, Base>
 where
     // `L - R` is valid
-    Sub<LB, RB>: NumExpr,
+    SubExp<LB, RB>: NumExpr,
     // `(L - R) - 1` is a valid expression
-    Sub<NumRet<Sub<LB, RB>>, _1>: NumExpr,
+    SubExp<NumRet<SubExp<LB, RB>>, _1>: NumExpr,
     // `(L - R) - 1` Is a valid bit-string literal so can be appended with a bit to make a valid
     // number
-    NumRet<Sub<NumRet<Sub<LB, RB>>, _1>>: BitStrLit,
+    NumRet<SubExp<NumRet<SubExp<LB, RB>>, _1>>: BitStrLit,
 {
-    type Ret = BitString<NumRet<Sub<NumRet<Sub<LB, RB>>, _1>>, _1>;
+    type Ret = BitString<NumRet<SubExp<NumRet<SubExp<LB, RB>>, _1>>, _1>;
 }
 /// (L)1 - (R)0 = (L - R)1
-impl<LB, RB> NumExpr for Sub<BitString<LB, _1>, BitString<RB, _0>, Base>
+impl<LB, RB> NumExpr for SubExp<BitString<LB, _1>, BitString<RB, _0>, Base>
 where
     // `L - R` is valid
-    Sub<LB, RB>: NumExpr,
+    SubExp<LB, RB>: NumExpr,
     // `(L - R)1` is valid as a bitstring
-    BitString<NumRet<Sub<LB, RB>>, _1>: NumExpr,
+    BitString<NumRet<SubExp<LB, RB>>, _1>: NumExpr,
 {
-    type Ret = NumRet<BitString<NumRet<Sub<LB, RB>>, _1>>;
+    type Ret = NumRet<BitString<NumRet<SubExp<LB, RB>>, _1>>;
 }
 
 /// (L)1 - (R)1 = (L - R)0
-impl<LB, RB> NumExpr for Sub<BitString<LB, _1>, BitString<RB, _1>, Base>
+impl<LB, RB> NumExpr for SubExp<BitString<LB, _1>, BitString<RB, _1>, Base>
 where
     // same operation as (L)0 - (R)0
-    Sub<BitString<LB, _0>, BitString<RB, _0>>: NumExpr,
+    SubExp<BitString<LB, _0>, BitString<RB, _0>>: NumExpr,
 {
-    type Ret = NumRet<Sub<BitString<LB, _0>, BitString<RB, _0>>>;
+    type Ret = NumRet<SubExp<BitString<LB, _0>, BitString<RB, _0>>>;
 }
 
 #[cfg(test)]
@@ -100,16 +100,16 @@ mod test {
     use crate::{test_res::*, U0, U1, U2, U3};
     #[test]
     fn eval_add() {
-        const _0_SUB_0: () = _b0::<Sub<U0, U0>>();
-        const _1_SUB_0: () = _b1::<Sub<U1, U0>>();
-        const _1_SUB_1: () = _b0::<Sub<U1, U1>>();
-        const _2_SUB_1: () = _b1::<Sub<U2, U1>>();
+        const _0_SUB_0: () = _b0::<SubExp<U0, U0>>();
+        const _1_SUB_0: () = _b1::<SubExp<U1, U0>>();
+        const _1_SUB_1: () = _b0::<SubExp<U1, U1>>();
+        const _2_SUB_1: () = _b1::<SubExp<U2, U1>>();
         // const _1_SUB_2: () = _b3::<Sub<_1, BitString<_1, _0>>>();
-        const _3_SUB_1: () = _b2::<Sub<U3, _1>>();
+        const _3_SUB_1: () = _b2::<SubExp<U3, _1>>();
         // const _4_SUB_1: () = _b3::<Sub<U4, _1>>();
         // const _1_SUB_3: () = _b4::<Sub<_1, BitString<_1, _1>>>();
-        const _2_SUB_2: () = _b0::<Sub<U2, U2>>();
-        const _3_SUB_2: () = _b1::<Sub<U3, U2>>();
-        const _3_SUB_3: () = _b0::<Sub<U3, U3>>();
+        const _2_SUB_2: () = _b0::<SubExp<U2, U2>>();
+        const _3_SUB_2: () = _b1::<SubExp<U3, U2>>();
+        const _3_SUB_3: () = _b0::<SubExp<U3, U3>>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod ctrl_types;
 mod op_types;
 mod val_types;
 use ctrl_types::BoolVal;
-use val_types::NumberVal;
+use val_types::{BitString, NumberVal, _0, _1};
 mod expr;
 
 pub trait ExprMode {}
@@ -21,6 +21,29 @@ pub trait BoolExpr {
     type Ret: BoolVal;
 }
 type BoolRet<T> = <T as BoolExpr>::Ret;
+
+// Some initial type aliases before refining the generator
+pub type U0 = _0;
+pub type U1 = _1;
+pub type U2 = BitString<_1, _0>;
+pub type U3 = BitString<_1, _1>;
+pub type U4 = BitString<U2, _0>;
+pub type U5 = BitString<U2, _1>;
+pub type U6 = BitString<U3, _0>;
+pub type U7 = BitString<U3, _1>;
+pub type U8 = BitString<U4, _0>;
+pub type U9 = BitString<U4, _1>;
+pub type U10 = BitString<U5, _0>;
+pub type U11 = BitString<U5, _1>;
+pub type U12 = BitString<U6, _0>;
+pub type U13 = BitString<U6, _1>;
+pub type U14 = BitString<U7, _0>;
+pub type U15 = BitString<U7, _1>;
+pub type U16 = BitString<U8, _0>;
+pub type U17 = BitString<U8, _1>;
+pub type U18 = BitString<U9, _0>;
+pub type U19 = BitString<U9, _1>;
+
 #[cfg(test)]
 mod test_res {
     use ctrl_types::{False, True};
@@ -31,14 +54,14 @@ mod test_res {
     use super::*;
     pub(crate) const fn _b0<E: NumExpr<Ret = _0>>() {}
     pub(crate) const fn _b1<E: NumExpr<Ret = _1>>() {}
-    pub(crate) const fn _b2<E: NumExpr<Ret = BitString<_1, _0>>>() {}
-    pub(crate) const fn _b3<E: NumExpr<Ret = BitString<_1, _1>>>() {}
-    pub(crate) const fn _b4<E: NumExpr<Ret = BitString<BitString<_1, _0>, _0>>>() {}
-    pub(crate) const fn _b5<E: NumExpr<Ret = BitString<BitString<_1, _0>, _1>>>() {}
-    pub(crate) const fn _b6<E: NumExpr<Ret = BitString<BitString<_1, _1>, _0>>>() {}
-    pub(crate) const fn _b7<E: NumExpr<Ret = BitString<BitString<_1, _1>, _1>>>() {}
-    pub(crate) const fn _b8<E: NumExpr<Ret = BitString<BitString<BitString<_1, _0>, _0>, _0>>>() {}
-    pub(crate) const fn _b9<E: NumExpr<Ret = BitString<BitString<BitString<_1, _0>, _0>, _1>>>() {}
+    pub(crate) const fn _b2<E: NumExpr<Ret = U2>>() {}
+    pub(crate) const fn _b3<E: NumExpr<Ret = U3>>() {}
+    pub(crate) const fn _b4<E: NumExpr<Ret = U4>>() {}
+    pub(crate) const fn _b5<E: NumExpr<Ret = U5>>() {}
+    pub(crate) const fn _b6<E: NumExpr<Ret = U6>>() {}
+    pub(crate) const fn _b7<E: NumExpr<Ret = U7>>() {}
+    pub(crate) const fn _b8<E: NumExpr<Ret = U8>>() {}
+    pub(crate) const fn _b9<E: NumExpr<Ret = U9>>() {}
 
     pub(crate) const fn _t<E: BoolExpr<Ret = True>>() {}
     pub(crate) const fn _f<E: BoolExpr<Ret = False>>() {}

--- a/src/op_types.rs
+++ b/src/op_types.rs
@@ -6,10 +6,9 @@ pub struct AddExp<Lhs, Rhs> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
 }
-pub struct SubExp<Lhs, Rhs, M = Recurse> {
+pub struct SubExp<Lhs, Rhs> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
-    _m: PhantomData<M>,
 }
 pub struct MulExp<Lhs, Rhs, M = Recurse> {
     _l: PhantomData<Lhs>,

--- a/src/op_types.rs
+++ b/src/op_types.rs
@@ -2,17 +2,17 @@ use core::marker::PhantomData;
 
 use crate::Recurse;
 
-pub struct Add<Lhs, Rhs, M = Recurse> {
+pub struct AddExp<Lhs, Rhs, M = Recurse> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
     _m: PhantomData<M>,
 }
-pub struct Sub<Lhs, Rhs, M = Recurse> {
+pub struct SubExp<Lhs, Rhs, M = Recurse> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
     _m: PhantomData<M>,
 }
-pub struct Mul<Lhs, Rhs, M = Recurse> {
+pub struct MulExp<Lhs, Rhs, M = Recurse> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
     _m: PhantomData<M>,
@@ -27,12 +27,12 @@ pub struct Mul<Lhs, Rhs, M = Recurse> {
 //     _m: PhantomData<M>,
 // }
 //
-pub struct ShL<Bs, N, M = Recurse> {
+pub struct ShLExp<Bs, N, M = Recurse> {
     _bits: PhantomData<Bs>,
     _shift_count: PhantomData<N>,
     _mode: PhantomData<M>,
 }
-pub struct ShR<Bs, N, M = Recurse> {
+pub struct ShRExp<Bs, N, M = Recurse> {
     _bits: PhantomData<Bs>,
     _shift_count: PhantomData<N>,
     _mode: PhantomData<M>,

--- a/src/op_types.rs
+++ b/src/op_types.rs
@@ -2,10 +2,9 @@ use core::marker::PhantomData;
 
 use crate::Recurse;
 
-pub struct AddExp<Lhs, Rhs, M = Recurse> {
+pub struct AddExp<Lhs, Rhs> {
     _l: PhantomData<Lhs>,
     _r: PhantomData<Rhs>,
-    _m: PhantomData<M>,
 }
 pub struct SubExp<Lhs, Rhs, M = Recurse> {
     _l: PhantomData<Lhs>,


### PR DESCRIPTION
The entry point to an evaluation uses a struct object for the operation used ("impl expr for add"), but it resolves the expression using `core::ops::*` traits.

This resolves the issue of the type system getting into an base-case-free recursion.

