### PR TITLE
Add ordering expression

### DIFF
--- a/src/ctrl_types.rs
+++ b/src/ctrl_types.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    BoolExpr,
+    BoolExpr, OrdExpr,
     _inners::{_ExprMode, _Recurse},
 };
 
@@ -16,6 +16,25 @@ impl BoolExpr for True {
     type Ret = Self;
 }
 impl BoolExpr for False {
+    type Ret = Self;
+}
+
+pub trait OrdVal {}
+
+pub struct Less;
+impl OrdVal for Less {}
+pub struct Gr8r;
+impl OrdVal for Gr8r {}
+pub struct Eq;
+impl OrdVal for Eq {}
+
+impl OrdExpr for Less {
+    type Ret = Self;
+}
+impl OrdExpr for Gr8r {
+    type Ret = Self;
+}
+impl OrdExpr for Eq {
     type Ret = Self;
 }
 
@@ -65,4 +84,10 @@ pub struct OR<L, R, M: _ExprMode = _Recurse> {
 }
 pub struct NOT<B> {
     _bool: PhantomData<B>,
+}
+
+pub struct ORD<L, R, M: _ExprMode = _Recurse> {
+    _l: PhantomData<L>,
+    _r: PhantomData<R>,
+    _m: PhantomData<M>,
 }

--- a/src/expr/cmp.rs
+++ b/src/expr/cmp.rs
@@ -3,6 +3,7 @@ mod eq;
 mod gt;
 mod lt;
 mod ltegte;
+mod ord;
 
 #[cfg(test)]
 mod test {

--- a/src/expr/cmp/gt.rs
+++ b/src/expr/cmp/gt.rs
@@ -1,8 +1,10 @@
+use core::marker::PhantomData;
+
 use crate::{
-    _inners::{_Base, _BitLit, _BitStrLit},
+    _inners::_Base,
     ctrl_types::{False, True, GT},
-    prelude::B as BitString,
-    val_types::{_0, _1},
+    prelude::BoolVal,
+    val_types::{B, _0, _1},
     BoolExpr, BoolRet, NumExpr,
 };
 
@@ -26,39 +28,90 @@ impl BoolExpr for GT<_0, _0, _Base> {
 impl BoolExpr for GT<_1, _1, _Base> {
     type Ret = False;
 }
-
-impl<Bs, B, R> BoolExpr for GT<BitString<Bs, B>, R, _Base>
+impl<LBs, LB, RBs, RB> BoolExpr for GT<B<LBs, LB>, B<RBs, RB>, _Base>
 where
-    Bs: _BitStrLit,
-    B: _BitLit,
-    R: _BitLit,
+    GT<LB, RB, _Base>: BoolExpr,
+    _BitwiseGT<BoolRet<GT<LB, RB, _Base>>, LBs, RBs>: BoolExpr,
+{
+    type Ret = BoolRet<_BitwiseGT<BoolRet<GT<LB, RB, _Base>>, LBs, RBs>>;
+}
+impl<RBs, RB> BoolExpr for GT<_0, B<RBs, RB>, _Base> {
+    type Ret = False;
+}
+impl<RBs, RB> BoolExpr for GT<_1, B<RBs, RB>, _Base> {
+    type Ret = False;
+}
+impl<LBs, LB> BoolExpr for GT<B<LBs, LB>, _1, _Base> {
+    type Ret = True;
+}
+impl<LBs, LB> BoolExpr for GT<B<LBs, LB>, _0, _Base> {
+    type Ret = True;
+}
+
+pub struct _BitwiseGT<C: BoolVal, L, R> {
+    _cache: PhantomData<C>,
+    _lhs: PhantomData<L>,
+    _rhs: PhantomData<R>,
+}
+impl<C, RBs, RB> BoolExpr for _BitwiseGT<C, _1, B<RBs, RB>>
+where
+    C: BoolVal,
+{
+    type Ret = False;
+}
+impl<C> BoolExpr for _BitwiseGT<C, _1, _1>
+where
+    C: BoolVal,
+{
+    type Ret = C;
+}
+impl<C, LBs, LB> BoolExpr for _BitwiseGT<C, B<LBs, LB>, _1>
+where
+    C: BoolVal,
 {
     type Ret = True;
 }
 
-impl<Bs, B, L> BoolExpr for GT<L, BitString<Bs, B>, _Base>
+impl<C, LBs, LB> BoolExpr for _BitwiseGT<C, B<LBs, LB>, _0>
 where
-    Bs: _BitStrLit,
-    B: _BitLit,
-    L: _BitLit,
+    C: BoolVal,
 {
-    type Ret = False;
+    type Ret = True;
 }
-impl<LBs, LB, RBs, RB> BoolExpr for GT<BitString<LBs, LB>, BitString<RBs, RB>, _Base>
+
+impl<C, LBs, RBs> BoolExpr for _BitwiseGT<C, B<LBs, _0>, B<RBs, _0>>
 where
-    LBs: _BitStrLit,
-    LB: _BitLit,
-    RBs: _BitStrLit,
-    RB: _BitLit,
-    GT<LB, RB>: BoolExpr,
+    C: BoolVal,
+    _BitwiseGT<C, LBs, RBs>: BoolExpr,
 {
-    type Ret = BoolRet<GT<LB, RB>>;
+    type Ret = BoolRet<_BitwiseGT<C, LBs, RBs>>;
+}
+impl<C, LBs, RBs> BoolExpr for _BitwiseGT<C, B<LBs, _1>, B<RBs, _1>>
+where
+    C: BoolVal,
+    _BitwiseGT<C, LBs, RBs>: BoolExpr,
+{
+    type Ret = BoolRet<_BitwiseGT<C, LBs, RBs>>;
+}
+impl<C, LBs, RBs> BoolExpr for _BitwiseGT<C, B<LBs, _0>, B<RBs, _1>>
+where
+    C: BoolVal,
+    _BitwiseGT<False, LBs, RBs>: BoolExpr,
+{
+    type Ret = BoolRet<_BitwiseGT<False, LBs, RBs>>;
+}
+impl<C, LBs, RBs> BoolExpr for _BitwiseGT<C, B<LBs, _1>, B<RBs, _0>>
+where
+    C: BoolVal,
+    _BitwiseGT<True, LBs, RBs>: BoolExpr,
+{
+    type Ret = BoolRet<_BitwiseGT<True, LBs, RBs>>;
 }
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::{
-        num_vals::{U0, U1, U2, U3, U4, U6, U7},
+        num_vals::{U0, U1, U2, U3, U4, U5, U6, U7},
         test_res::*,
     };
     #[test]
@@ -67,10 +120,13 @@ mod test {
         const _1_GT_0: () = _t::<GT<U1, U0>>();
         const _1_GT_1: () = _f::<GT<U1, U1>>();
         const _2_GT_1: () = _t::<GT<U2, U1>>();
+        const _2_GT_0: () = _t::<GT<U2, U0>>();
+        const _2_GT_4: () = _f::<GT<U2, U4>>();
         const _1_GT_2: () = _f::<GT<U1, U2>>();
         const _3_GT_1: () = _t::<GT<U3, U1>>();
         const _4_GT_1: () = _t::<GT<U4, U1>>();
-        // const _5_GT_6: () = _f::<GT<U5, U6>>();
+        const _4_GT_2: () = _t::<GT<U4, U2>>();
+        const _5_GT_6: () = _f::<GT<U5, U6>>();
         const _1_GT_3: () = _f::<GT<U1, U3>>();
         const _1_GT_4: () = _f::<GT<U1, U4>>();
         const _2_GT_2: () = _f::<GT<U2, U2>>();

--- a/src/expr/cmp/lt.rs
+++ b/src/expr/cmp/lt.rs
@@ -71,6 +71,7 @@ mod test {
         const _1_LT_2: () = _t::<LT<U1, U2>>();
         const _3_LT_1: () = _f::<LT<U3, U1>>();
         const _4_LT_1: () = _f::<LT<U4, U1>>();
+        const _4_LT_2: () = _f::<LT<U4, U2>>();
         // const _5_LT_6: () = _t::<LT<U5, U6>>();
         const _1_LT_3: () = _t::<LT<U1, U3>>();
         const _1_LT_4: () = _t::<LT<U1, U4>>();

--- a/src/expr/cmp/lt.rs
+++ b/src/expr/cmp/lt.rs
@@ -1,65 +1,19 @@
-use crate::{
-    _inners::{_Base, _BitLit, _BitStrLit},
-    ctrl_types::{False, True, LT},
-    prelude::B as BitString,
-    val_types::{_0, _1},
-    BoolExpr, BoolRet, NumExpr,
-};
+use crate::{_inners::_Base, ctrl_types::LT, prelude::GT, BoolExpr, BoolRet, NumExpr};
 
 impl<L, R> BoolExpr for LT<L, R>
 where
     L: NumExpr,
     R: NumExpr,
-    LT<L::Ret, R::Ret, _Base>: BoolExpr,
+    GT<R::Ret, L::Ret, _Base>: BoolExpr,
 {
-    type Ret = BoolRet<LT<L::Ret, R::Ret, _Base>>;
-}
-impl BoolExpr for LT<_1, _0, _Base> {
-    type Ret = False;
-}
-impl BoolExpr for LT<_0, _1, _Base> {
-    type Ret = True;
-}
-impl BoolExpr for LT<_0, _0, _Base> {
-    type Ret = False;
-}
-impl BoolExpr for LT<_1, _1, _Base> {
-    type Ret = False;
-}
-
-impl<Bs, B, R> BoolExpr for LT<BitString<Bs, B>, R, _Base>
-where
-    Bs: _BitStrLit,
-    B: _BitLit,
-    R: _BitLit,
-{
-    type Ret = False;
-}
-
-impl<Bs, B, L> BoolExpr for LT<L, BitString<Bs, B>, _Base>
-where
-    Bs: _BitStrLit,
-    B: _BitLit,
-    L: _BitLit,
-{
-    type Ret = True;
-}
-impl<LBs, LB, RBs, RB> BoolExpr for LT<BitString<LBs, LB>, BitString<RBs, RB>, _Base>
-where
-    LBs: _BitStrLit,
-    LB: _BitLit,
-    RBs: _BitStrLit,
-    RB: _BitLit,
-    LT<LB, RB>: BoolExpr,
-{
-    type Ret = BoolRet<LT<LB, RB>>;
+    type Ret = BoolRet<GT<R::Ret, L::Ret, _Base>>;
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::{
-        num_vals::{U0, U1, U2, U3, U4, U6, U7},
+        num_vals::{U0, U1, U2, U3, U4, U5, U6, U7},
         test_res::*,
     };
     #[test]
@@ -72,7 +26,7 @@ mod test {
         const _3_LT_1: () = _f::<LT<U3, U1>>();
         const _4_LT_1: () = _f::<LT<U4, U1>>();
         const _4_LT_2: () = _f::<LT<U4, U2>>();
-        // const _5_LT_6: () = _t::<LT<U5, U6>>();
+        const _5_LT_6: () = _t::<LT<U5, U6>>();
         const _1_LT_3: () = _t::<LT<U1, U3>>();
         const _1_LT_4: () = _t::<LT<U1, U4>>();
         const _2_LT_2: () = _f::<LT<U2, U2>>();

--- a/src/expr/cmp/ltegte.rs
+++ b/src/expr/cmp/ltegte.rs
@@ -1,26 +1,66 @@
 use crate::{
-    _inners::_Base,
-    ctrl_types::{AND, EQ, GT, GTE, LT, LTE},
-    BoolExpr, BoolRet, NumExpr,
+    ctrl_types::{GT, GTE, LTE},
+    num_vals::U1,
+    op_types::AddExp,
+    prelude::LT,
+    BoolExpr, BoolRet, NumExpr, NumRet,
 };
 
 impl<L, R> BoolExpr for GTE<L, R>
 where
-    L: NumExpr,
-    R: NumExpr,
-    GT<L::Ret, R::Ret, _Base>: BoolExpr,
-    EQ<L::Ret, R::Ret, _Base>: BoolExpr,
-    AND<GT<L::Ret, R::Ret, _Base>, EQ<L::Ret, R::Ret, _Base>>: BoolExpr,
+    AddExp<L, U1>: NumExpr,
+    GT<NumRet<AddExp<L, U1>>, R>: BoolExpr,
 {
-    type Ret = BoolRet<AND<GT<L::Ret, R::Ret, _Base>, EQ<L::Ret, R::Ret, _Base>>>;
+    type Ret = BoolRet<GT<NumRet<AddExp<L, U1>>, R>>;
 }
 impl<L, R> BoolExpr for LTE<L, R>
 where
-    L: NumExpr,
-    R: NumExpr,
-    LT<L::Ret, R::Ret, _Base>: BoolExpr,
-    EQ<L::Ret, R::Ret, _Base>: BoolExpr,
-    AND<LT<L::Ret, R::Ret, _Base>, EQ<L::Ret, R::Ret, _Base>>: BoolExpr,
+    AddExp<R, U1>: NumExpr,
+    LT<L, NumRet<AddExp<R, U1>>>: BoolExpr,
 {
-    type Ret = BoolRet<AND<LT<L::Ret, R::Ret, _Base>, EQ<L::Ret, R::Ret, _Base>>>;
+    type Ret = BoolRet<LT<L, NumRet<AddExp<R, U1>>>>;
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        num_vals::{U0, U1, U2, U3, U4, U5, U6, U7},
+        test_res::*,
+    };
+    #[test]
+    fn eval_lte() {
+        const _0_LTE_0: () = _t::<LTE<U0, U0>>();
+        const _1_LTE_0: () = _f::<LTE<U1, U0>>();
+        const _1_LTE_1: () = _t::<LTE<U1, U1>>();
+        const _2_LTE_1: () = _f::<LTE<U2, U1>>();
+        const _1_LTE_2: () = _t::<LTE<U1, U2>>();
+        const _3_LTE_1: () = _f::<LTE<U3, U1>>();
+        const _4_LTE_1: () = _f::<LTE<U4, U1>>();
+        const _5_LTE_6: () = _t::<LTE<U5, U6>>();
+        const _1_LTE_3: () = _t::<LTE<U1, U3>>();
+        const _1_LTE_4: () = _t::<LTE<U1, U4>>();
+        const _2_LTE_2: () = _t::<LTE<U2, U2>>();
+        const _3_LTE_3: () = _t::<LTE<U3, U3>>();
+        const _6_LTE_1: () = _f::<LTE<U6, U1>>();
+        const _7_LTE_1: () = _f::<LTE<U7, U1>>();
+    }
+    #[test]
+    fn eval_gte() {
+        const _0_GTE_0: () = _t::<GTE<U0, U0>>();
+        const _1_GTE_0: () = _t::<GTE<U1, U0>>();
+        const _1_GTE_1: () = _t::<GTE<U1, U1>>();
+        const _2_GTE_1: () = _t::<GTE<U2, U1>>();
+        const _2_GTE_4: () = _f::<GTE<U2, U4>>();
+        const _1_GTE_2: () = _f::<GTE<U1, U2>>();
+        const _3_GTE_1: () = _t::<GTE<U3, U1>>();
+        const _4_GTE_1: () = _t::<GTE<U4, U1>>();
+        const _4_GTE_2: () = _t::<GTE<U4, U2>>();
+        const _5_GTE_6: () = _f::<GTE<U5, U6>>();
+        const _1_GTE_3: () = _f::<GTE<U1, U3>>();
+        const _1_GTE_4: () = _f::<GTE<U1, U4>>();
+        const _2_GTE_2: () = _t::<GTE<U2, U2>>();
+        const _3_GTE_3: () = _t::<GTE<U3, U3>>();
+        const _6_GTE_1: () = _t::<GTE<U6, U1>>();
+        const _7_GTE_1: () = _t::<GTE<U7, U1>>();
+    }
 }

--- a/src/expr/cmp/ord.rs
+++ b/src/expr/cmp/ord.rs
@@ -1,0 +1,139 @@
+use core::marker::PhantomData;
+
+use crate::{
+    ctrl_types::{Eq, Gr8r, Less, OrdVal, ORD},
+    val_types::{NumberVal, B, _0, _1},
+    NumExpr, NumRet, OrdExpr, OrdRet,
+    _inners::{_Base, _BitLit},
+};
+
+impl<Lhs, Rhs> OrdExpr for ORD<Lhs, Rhs>
+where
+    Lhs: NumExpr,
+    Rhs: NumExpr,
+    NumRet<Lhs>: NumberVal,
+    NumRet<Rhs>: NumberVal,
+    ORD<NumRet<Lhs>, NumRet<Rhs>, _Base>: OrdExpr,
+{
+    type Ret = OrdRet<ORD<NumRet<Lhs>, NumRet<Rhs>, _Base>>;
+}
+
+impl OrdExpr for ORD<_0, _0, _Base> {
+    type Ret = Eq;
+}
+impl OrdExpr for ORD<_0, _1, _Base> {
+    type Ret = Less;
+}
+impl OrdExpr for ORD<_1, _0, _Base> {
+    type Ret = Gr8r;
+}
+impl OrdExpr for ORD<_1, _1, _Base> {
+    type Ret = Eq;
+}
+impl<LBs, LB, RB> OrdExpr for ORD<B<LBs, LB>, RB, _Base>
+where
+    RB: _BitLit,
+{
+    type Ret = Gr8r;
+}
+impl<LB, RBs, RB> OrdExpr for ORD<LB, B<RBs, RB>, _Base>
+where
+    LB: _BitLit,
+{
+    type Ret = Less;
+}
+impl<LBs, LB, RBs, RB> OrdExpr for ORD<B<LBs, LB>, B<RBs, RB>, _Base>
+where
+    BitwiseORD<Eq, B<LBs, LB>, B<RBs, RB>>: OrdExpr,
+{
+    type Ret = OrdRet<BitwiseORD<Eq, B<LBs, LB>, B<RBs, RB>>>;
+}
+
+pub struct BitwiseORD<C: OrdVal, L, R> {
+    _cache: PhantomData<C>,
+    _lhs: PhantomData<L>,
+    _rhs: PhantomData<R>,
+}
+impl<C, RBs, RB> OrdExpr for BitwiseORD<C, _1, B<RBs, RB>>
+where
+    C: OrdVal,
+{
+    type Ret = Less;
+}
+impl<C> OrdExpr for BitwiseORD<C, _1, _1>
+where
+    C: OrdVal,
+{
+    type Ret = C;
+}
+impl<C, LBs, LB> OrdExpr for BitwiseORD<C, B<LBs, LB>, _1>
+where
+    C: OrdVal,
+{
+    type Ret = Gr8r;
+}
+
+impl<C, LBs, LB> OrdExpr for BitwiseORD<C, B<LBs, LB>, _0>
+where
+    C: OrdVal,
+{
+    type Ret = Gr8r;
+}
+
+impl<C, LBs, RBs> OrdExpr for BitwiseORD<C, B<LBs, _0>, B<RBs, _0>>
+where
+    C: OrdVal,
+    BitwiseORD<C, LBs, RBs>: OrdExpr,
+{
+    type Ret = OrdRet<BitwiseORD<C, LBs, RBs>>;
+}
+impl<C, LBs, RBs> OrdExpr for BitwiseORD<C, B<LBs, _1>, B<RBs, _1>>
+where
+    C: OrdVal,
+    BitwiseORD<C, LBs, RBs>: OrdExpr,
+{
+    type Ret = OrdRet<BitwiseORD<C, LBs, RBs>>;
+}
+impl<C, LBs, RBs> OrdExpr for BitwiseORD<C, B<LBs, _0>, B<RBs, _1>>
+where
+    C: OrdVal,
+    BitwiseORD<Less, LBs, RBs>: OrdExpr,
+{
+    type Ret = OrdRet<BitwiseORD<Less, LBs, RBs>>;
+}
+impl<C, LBs, RBs> OrdExpr for BitwiseORD<C, B<LBs, _1>, B<RBs, _0>>
+where
+    C: OrdVal,
+    BitwiseORD<Gr8r, LBs, RBs>: OrdExpr,
+{
+    type Ret = OrdRet<BitwiseORD<Gr8r, LBs, RBs>>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        num_vals::{U0, U1, U2, U3, U4, U5, U6, U7},
+        test_res::*,
+    };
+    #[test]
+    fn eval_ord() {
+        const _0_ORD_0: () = _eq::<ORD<_0, _0>>();
+        const _1_ORD_0: () = _gt::<ORD<_1, _0>>();
+        const _1_ORD_1: () = _eq::<ORD<U1, U1>>();
+        const _2_ORD_0: () = _gt::<ORD<U2, U0>>();
+        const _0_ORD_2: () = _lt::<ORD<U0, U2>>();
+        const _2_ORD_1: () = _gt::<ORD<U2, U1>>();
+        const _1_ORD_2: () = _lt::<ORD<U1, U2>>();
+        const _3_ORD_1: () = _gt::<ORD<U3, U1>>();
+        const _4_ORD_1: () = _gt::<ORD<U4, U1>>();
+        const _5_ORD_6: () = _lt::<ORD<U5, U6>>();
+        const _6_ORD_5: () = _gt::<ORD<U6, U5>>();
+        const _1_ORD_3: () = _lt::<ORD<U1, U3>>();
+        const _1_ORD_4: () = _lt::<ORD<U1, U4>>();
+        const _2_ORD_2: () = _eq::<ORD<U2, U2>>();
+        const _3_ORD_3: () = _eq::<ORD<U3, U3>>();
+        const _6_ORD_1: () = _gt::<ORD<U6, U1>>();
+        const _7_ORD_1: () = _gt::<ORD<U7, U1>>();
+    }
+}

--- a/src/expr/if_branch.rs
+++ b/src/expr/if_branch.rs
@@ -71,14 +71,15 @@ where
 mod test {
     use super::*;
     use crate::{
-        num_vals::{U0, U1, U2},
+        num_vals::{U0, U1, U2, U3},
+        op_types::AddExp,
         prelude::{MulExp, GT, LT, U5},
         test_res::*,
     };
     #[test]
-    fn eval_add() {
+    fn eval_if() {
         const _IF_T_1_2: () = _b1::<IF<LT<U0, U1>, U1, U2>>();
         const _IF_F_1_2: () = _b2::<IF<GT<U0, U1>, U1, U2>>();
-        const _ARITH: () = _b10::<IF<LT<U1, U2>, MulExp<U2, U5>, U0>>();
+        const _ARITH: () = _b10::<IF<LT<AddExp<U2, U3>, MulExp<U2, U3>>, MulExp<U2, U5>, U0>>();
     }
 }

--- a/src/expr/if_branch.rs
+++ b/src/expr/if_branch.rs
@@ -1,6 +1,6 @@
 use crate::{
     prelude::{False, True, IF},
-    BoolExpr, BoolRet, NumExpr, NumRet,
+    BoolExpr, BoolRet, NumExpr, NumRet, OrdExpr, OrdRet,
     _inners::_Base,
 };
 
@@ -45,6 +45,27 @@ where
     F: BoolExpr,
 {
     type Ret = BoolRet<F>;
+}
+impl<C, T, F> OrdExpr for IF<C, T, F>
+where
+    C: BoolExpr,
+    BoolRet<C>: BoolExpr,
+    IF<C::Ret, T, F, _Base>: OrdExpr,
+{
+    type Ret = OrdRet<IF<C::Ret, T, F, _Base>>;
+}
+
+impl<T, F> OrdExpr for IF<True, T, F, _Base>
+where
+    T: OrdExpr,
+{
+    type Ret = OrdRet<T>;
+}
+impl<T, F> OrdExpr for IF<False, T, F, _Base>
+where
+    F: OrdExpr,
+{
+    type Ret = OrdRet<F>;
 }
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,16 @@ pub trait BoolExpr {
 }
 /// <T as [BoolExpr]>::Ret helper
 pub type BoolRet<T> = <T as BoolExpr>::Ret;
+/// An expression returning a [`prelude::BoolVal`]
+pub trait OrdExpr {
+    type Ret: prelude::OrdVal;
+}
+/// <T as [BoolExpr]>::Ret helper
+pub type OrdRet<T> = <T as OrdExpr>::Ret;
 
 #[cfg(test)]
 mod test_res {
-    use ctrl_types::{False, True};
+    use ctrl_types::{Eq, False, Gr8r, Less, True};
     use val_types::B as BitString;
     use val_types::_0;
 
@@ -91,6 +97,9 @@ mod test_res {
 
     pub(crate) const fn _t<E: BoolExpr<Ret = True>>() {}
     pub(crate) const fn _f<E: BoolExpr<Ret = False>>() {}
+    pub(crate) const fn _lt<E: OrdExpr<Ret = Less>>() {}
+    pub(crate) const fn _eq<E: OrdExpr<Ret = Eq>>() {}
+    pub(crate) const fn _gt<E: OrdExpr<Ret = Gr8r>>() {}
     #[test]
     fn eval_add() {
         const _0_0: () = _b0::<BitString<_0, _0>>();


### PR DESCRIPTION
allows the type equivilent of `std::cmp::Ord::cmp(self, other)`, as well as fixes some LT-and-friends errors.